### PR TITLE
Import legacy Classic Shell data (#28)

### DIFF
--- a/Src/StartMenu/Legacy.cpp
+++ b/Src/StartMenu/Legacy.cpp
@@ -1,0 +1,41 @@
+#include "stdafx.h"
+#include <filesystem>
+namespace fs = std::experimental::filesystem;
+
+static void CopyRegKey(HKEY root, const wchar_t* srcKey, const wchar_t* dstKey)
+{
+	CRegKey src;
+	if (src.Open(root, srcKey, KEY_READ | KEY_WOW64_64KEY) == ERROR_SUCCESS)
+	{
+		CRegKey dst;
+		if (dst.Create(root, dstKey, nullptr, 0, KEY_ALL_ACCESS | KEY_WOW64_64KEY, nullptr, nullptr) == ERROR_SUCCESS)
+			::RegCopyTree(src, nullptr, dst);
+	}
+}
+
+static void CopyFolder(const wchar_t* srcPath, const wchar_t* dstPath)
+{
+	wchar_t src[MAX_PATH]{};
+	::ExpandEnvironmentStrings(srcPath, src, _countof(src));
+
+	wchar_t dst[MAX_PATH]{};
+	::ExpandEnvironmentStrings(dstPath, dst, _countof(dst));
+
+	std::error_code err;
+	fs::copy(src, dst, fs::copy_options::recursive | fs::copy_options::update_existing, err);
+}
+
+void ImportLegacyData()
+{
+	CRegKey reg;
+	if (reg.Open(HKEY_CURRENT_USER, L"Software\\OpenShell", KEY_READ | KEY_WOW64_64KEY) == ERROR_FILE_NOT_FOUND)
+	{
+		CopyRegKey(HKEY_CURRENT_USER, L"Software\\IvoSoft\\ClassicExplorer", L"Software\\OpenShell\\ClassicExplorer");
+		CopyRegKey(HKEY_CURRENT_USER, L"Software\\IvoSoft\\ClassicIE", L"Software\\OpenShell\\ClassicIE");
+		CopyRegKey(HKEY_CURRENT_USER, L"Software\\IvoSoft\\ClassicShell", L"Software\\OpenShell\\OpenShell");
+		CopyRegKey(HKEY_CURRENT_USER, L"Software\\IvoSoft\\ClassicStartMenu", L"Software\\OpenShell\\StartMenu");
+
+		CopyFolder(L"%APPDATA%\\ClassicShell", L"%APPDATA%\\OpenShell");
+		CopyFolder(L"%LOCALAPPDATA%\\ClassicShell", L"%LOCALAPPDATA%\\OpenShell");
+	}
+}

--- a/Src/StartMenu/Legacy.h
+++ b/Src/StartMenu/Legacy.h
@@ -1,0 +1,2 @@
+// import legacy Classic Shell settings/data if we don't have any yet
+void ImportLegacyData();

--- a/Src/StartMenu/StartMenu.cpp
+++ b/Src/StartMenu/StartMenu.cpp
@@ -11,6 +11,7 @@
 #include "ComHelper.h"
 #include "Settings.h"
 #include "psapi.h"
+#include "Legacy.h"
 
 #include "StartMenuDLL\StartMenuDLL.h"
 #include "StartMenuDLL\SettingsUI.h"
@@ -334,6 +335,9 @@ int WINAPI wWinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpstrC
 			PropVariantClear(&val);
 		}
 	}*/
+
+	// one-time import from Classic Shell
+	ImportLegacyData();
 
 	DllLogToFile(STARTUP_LOG,L"StartMenu: start '%s'",lpstrCmdLine);
 	DWORD winVer=GetVersionEx(GetModuleHandle(L"user32.dll"));

--- a/Src/StartMenu/StartMenu.vcxproj
+++ b/Src/StartMenu/StartMenu.vcxproj
@@ -271,6 +271,7 @@
     <Text Include="..\Localization\English\MenuADMX.txt" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Legacy.cpp" />
     <ClCompile Include="StartMenu.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
@@ -283,6 +284,7 @@
     <ResourceCompile Include="StartMenu.rc" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Legacy.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="targetver.h" />


### PR DESCRIPTION
Copy data/settings from legacy Classic Shell if we don't have any yet.

We will check the `HKCU/OpenShell` key after installation (when `StartMenu.exe` starts). If it doesn't exist it means it is the fist `Open-Shell` installation and we'll try to copy data from `ClassicShell` locations.

I was thinking whether to copy or actually move legacy data. Decided to go with copy, so that it is possible to easily return to `ClassicShell` if necessary.