### PR TITLE
Setup improvements

### DIFF
--- a/Src/Setup/Setup.rc
+++ b/Src/Setup/Setup.rc
@@ -104,41 +104,6 @@ IDR_MSI_FILE32          MSI_FILE                "Temp\\Setup32.msi_"
 IDR_MSI_FILE64          MSI_FILE                "Temp\\Setup64.msi_"
 IDR_MSI_CHECKSUM        MSI_FILE                "msichecksum.bin"
 
-/////////////////////////////////////////////////////////////////////////////
-//
-// Dialog
-//
-
-IDD_DIALOGPWD DIALOGEX 0, 0, 154, 75
-STYLE DS_SETFONT | DS_MODALFRAME | DS_FIXEDSYS | DS_CENTER | WS_POPUP | WS_CAPTION | WS_SYSMENU
-CAPTION "Open-Shell 2.8.0 (closed beta)"
-FONT 8, "MS Shell Dlg", 400, 0, 0x1
-BEGIN
-    LTEXT           "This beta version is password-protected. Please enter the password:",IDC_STATIC,7,7,140,17
-    EDITTEXT        IDC_EDITPWD,7,32,140,14,ES_AUTOHSCROLL
-    DEFPUSHBUTTON   "OK",IDOK,43,54,50,14
-    PUSHBUTTON      "Cancel",IDCANCEL,97,54,50,14
-END
-
-
-/////////////////////////////////////////////////////////////////////////////
-//
-// DESIGNINFO
-//
-
-#ifdef APSTUDIO_INVOKED
-GUIDELINES DESIGNINFO 
-BEGIN
-    IDD_DIALOGPWD, DIALOG
-    BEGIN
-        LEFTMARGIN, 7
-        RIGHTMARGIN, 147
-        TOPMARGIN, 7
-        BOTTOMMARGIN, 68
-    END
-END
-#endif    // APSTUDIO_INVOKED
-
 
 /////////////////////////////////////////////////////////////////////////////
 //

--- a/Src/Setup/Setup.rc
+++ b/Src/Setup/Setup.rc
@@ -148,7 +148,6 @@ END
 STRINGTABLE 
 BEGIN
     IDS_APP_TITLE           "Open-Shell Setup"
-    IDS_OLDSTARTMENU        "Warning!\nAn old version of the classic start menu is still running. Please close it before installing the new version to avoid crashing Explorer. Right click on the start button and select ""Exit""."
     IDS_ERR_CORRUPTED       "Failed to extract setup file '%s'. The MSI resource is corrupted."
 END
 

--- a/Src/Setup/Setup.vcxproj
+++ b/Src/Setup/Setup.vcxproj
@@ -123,7 +123,6 @@
     <None Include="BuildInstaller.bat" />
     <None Include="Setup.wxs" />
     <None Include="msichecksum.bin" />
-    <None Include="SetEnvironment.bat" />
     <None Include="Temp\Setup32.msi_" />
     <None Include="Temp\Setup64.msi_" />
     <None Include="__MakeFinal.bat" />

--- a/Src/Setup/Setup.vcxproj.filters
+++ b/Src/Setup/Setup.vcxproj.filters
@@ -58,9 +58,6 @@
     <None Include="..\Localization\English\OpenShellText-en-US.wxl">
       <Filter>Setup Files</Filter>
     </None>
-    <None Include="SetEnvironment.bat">
-      <Filter>Setup Files</Filter>
-    </None>
     <None Include="Temp\Setup32.msi_" />
     <None Include="Temp\Setup64.msi_" />
     <None Include="msichecksum.bin" />

--- a/Src/Setup/resource.h
+++ b/Src/Setup/resource.h
@@ -9,7 +9,6 @@
 #define IDR_MSI_FILE32                  132
 #define IDR_MSI_FILE64                  164
 #define IDS_ERR_INTERNAL                166
-#define IDD_DIALOGPWD                   166
 #define IDS_ERR_EXTRACT                 167
 #define IDR_MSI_CHECKSUM                167
 #define IDS_ERR_WIN7                    169

--- a/Src/Setup/resource.h
+++ b/Src/Setup/resource.h
@@ -5,7 +5,6 @@
 #define IDS_APP_NAME                    100
 #define IDS_APP_TITLE                   100
 #define IDI_APPICON                     101
-#define IDS_OLDSTARTMENU                101
 #define IDS_ERR_CORRUPTED               102
 #define IDR_MSI_FILE32                  132
 #define IDR_MSI_FILE64                  164


### PR DESCRIPTION
- Remove warning about very old ClassicShell version
- Remove obsolete/unused stuff
- Try to terminate ClassicShell Start Menu (to make upgrade a bit easier)

Also fixes #72 along the way.