### PR TITLE
Fix Lock button hiding

### DIFF
--- a/Src/StartMenu/StartMenuDLL/MenuContainer.cpp
+++ b/Src/StartMenu/StartMenuDLL/MenuContainer.cpp
@@ -83,6 +83,7 @@ static StdMenuOption g_StdOptions[]=
 	{MENU_USERPICTURES,MENU_ENABLED}, // check policy
 	{MENU_SLEEP,MENU_ENABLED}, // check power caps
 	{MENU_HIBERNATE,MENU_ENABLED}, // check power caps
+	{MENU_LOCK,MENU_ENABLED}, // check power settings
 	{MENU_SWITCHUSER,MENU_ENABLED}, // check group policy
 	{MENU_APPS,MENU_ENABLED}, // enable on Win8+
 	{MENU_PCSETTINGS,MENU_ENABLED}, // enable on Win8+


### PR DESCRIPTION
Commit 1a5f62a added possibility to hide Lock/Sleep/Hibernate buttons if
they were disabled in system power settings.

Unfortunately this didn't work for Lock button.

To fix the behavior we have to add lock command to `g_StdOptions` array
and then all the checks introduced in 1a5f62a will apply properly.

 #173