### PR TITLE
Fix issue with confirmation dialog being blocked

### DIFF
--- a/Src/StartMenu/StartMenuDLL/DragDrop.cpp
+++ b/Src/StartMenu/StartMenuDLL/DragDrop.cpp
@@ -852,9 +852,14 @@ HRESULT STDMETHODCALLTYPE CMenuContainer::Drop( IDataObject *pDataObj, DWORD grf
 			CComQIPtr<IDataObjectAsyncCapability> pAsync=pDataObj;
 			if (pAsync)
 				pAsync->SetAsyncMode(FALSE);
-			for (std::vector<CMenuContainer*>::iterator it=s_Menus.begin();it!=s_Menus.end();++it)
-				if (!(*it)->m_bDestroyed)
-					(*it)->EnableWindow(FALSE); // disable all menus
+			for (auto& it : s_Menus)
+			{
+				if (!it->m_bDestroyed)
+				{
+					it->EnableWindow(FALSE); // disable all menus
+					it->SetWindowPos(HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+				}
+			}
 			bool bAllPrograms=s_bAllPrograms;
 			if (bAllPrograms) ::EnableWindow(g_TopWin7Menu,FALSE);
 			bool bOld=s_bPreventClosing;
@@ -862,9 +867,14 @@ HRESULT STDMETHODCALLTYPE CMenuContainer::Drop( IDataObject *pDataObj, DWORD grf
 			AddRef();
 			pTarget->Drop(pDataObj,grfKeyState,pt,pdwEffect);
 			s_bPreventClosing=bOld;
-			for (std::vector<CMenuContainer*>::iterator it=s_Menus.begin();it!=s_Menus.end();++it)
-				if (!(*it)->m_bDestroyed)
-					(*it)->EnableWindow(TRUE); // enable all menus
+			for (auto& it : s_Menus)
+			{
+				if (!it->m_bDestroyed)
+				{
+					it->EnableWindow(TRUE); // enable all menus
+					it->SetWindowPos(HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+				}
+			}
 			if (bAllPrograms) ::EnableWindow(g_TopWin7Menu,TRUE);
 		}
 		else

--- a/Src/StartMenu/StartMenuDLL/MenuCommands.cpp
+++ b/Src/StartMenu/StartMenuDLL/MenuCommands.cpp
@@ -2800,8 +2800,11 @@ void CMenuContainer::ActivateItem( int index, TActivateType type, const POINT *p
 				info.fMask|=CMIC_MASK_NOASYNC; // wait for delete/link commands to finish so we can refresh the menu
 
 			s_bPreventClosing=true;
-			for (std::vector<CMenuContainer*>::iterator it=s_Menus.begin();it!=s_Menus.end();++it)
-				(*it)->EnableWindow(FALSE); // disable all menus
+			for (auto& it : s_Menus)
+			{
+				it->EnableWindow(FALSE); // disable all menus
+				it->SetWindowPos(HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+			}
 			bool bAllPrograms=s_bAllPrograms;
 			if (bAllPrograms) ::EnableWindow(g_TopWin7Menu,FALSE);
 			info.hwnd=g_OwnerWindow;
@@ -2846,9 +2849,14 @@ void CMenuContainer::ActivateItem( int index, TActivateType type, const POINT *p
 					}
 				}
 			}
-			for (std::vector<CMenuContainer*>::iterator it=s_Menus.begin();it!=s_Menus.end();++it)
-				if (!(*it)->m_bDestroyed)
-					(*it)->EnableWindow(TRUE); // enable all menus
+			for (auto& it : s_Menus)
+			{
+				if (!it->m_bDestroyed)
+				{
+					it->EnableWindow(TRUE); // enable all menus
+					it->SetWindowPos(HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+				}
+			}
 			if (bAllPrograms) ::EnableWindow(g_TopWin7Menu,TRUE);
 			if (bRefreshMain && m_bSubMenu)
 			{


### PR DESCRIPTION
Delete confirmation dialog may be (partially) hidden behing start menu.
As a result the dialog may be not accessible because start menu(s) are
displayed as top-most windows.

Thus when executing menu command we will make menu(s) non-topmost. So that
other windows can be drawn on top of menu(s).

Fixes #257