### PR TITLE
Fix 'Invert Metro icon color' option for grayscale icons

### DIFF
--- a/Src/StartMenu/StartMenuDLL/Accessibility.cpp
+++ b/Src/StartMenu/StartMenuDLL/Accessibility.cpp
@@ -182,7 +182,7 @@ HRESULT STDMETHODCALLTYPE CMenuAccessible::accSelect( long flagsSelect, VARIANT 
 		int index=varChild.lVal-1;
 		if (index<0 || index>=(int)m_pOwner->m_Items.size())
 			return S_FALSE;
-		m_pOwner->ActivateItem(index,CMenuContainer::ACTIVATE_SELECT,NULL,false);
+		m_pOwner->ActivateItem(index,CMenuContainer::ACTIVATE_SELECT,NULL);
 	}
 	return S_OK;
 }

--- a/Src/StartMenu/StartMenuDLL/ItemManager.cpp
+++ b/Src/StartMenu/StartMenuDLL/ItemManager.cpp
@@ -142,10 +142,11 @@ static bool DetectGrayscaleImage( const unsigned int *bits, int stride, int widt
 		for (int x=0;x<width;x++)
 		{
 			unsigned int pixel=bits[x];
+			int a=(pixel>>24)&255;
 			int r=(pixel>>16)&255;
 			int g=(pixel>>8)&255;
 			int b=(pixel)&255;
-			if (abs(r-g)>2 || abs(r-b)>2 || abs(g-b)>2)
+			if (abs(a-r)>2 || abs(r-g)>2 || abs(r-b)>2 || abs(g-b)>2)
 				return false; // found colored pixel
 			if (!(pixel&0xFF000000))
 				transparent++;


### PR DESCRIPTION
When `Invert Metro icon color` is enabled `Open-Shell` needs to
distinguish full color icons from monochromatic ones.

Color icons are displayed normally. Monochromatic ones are displayed
inverted (original background becomes transparent and foreground will
get Metro accent color).

Metro icon is loaded from Metro app resources (usually PNG image) as
bitmap with premultiplied alpha channel.
This causes monochromatic image to essentially become grayscale (because
RGB values are multiplied with alpha channel value).

Function `DetectGrayscaleImage` is used to distinguish such images.

Unfortunatelly if original image is grayscale (such as new Windows
Terminal icon) it is recognized as monochromatic and thus inverted.

To prevent this we will take into account also alpha channel in
`DetectGrayscaleImage`.

In monochromatic images alpha channel value will be the same as the rest of
channel values.
For color images alpha channel value will be different than other
channel values.