### PR TITLE
Add null check to PremultiplyBitmap()

### DIFF
--- a/Src/Lib/ResourceHelper.cpp
+++ b/Src/Lib/ResourceHelper.cpp
@@ -332,6 +332,7 @@ HBITMAP BitmapFromIcon( HICON hIcon, int iconSize, unsigned int **pBits, bool bD
 // Premultiplies a DIB section by the alpha channel and a given color
 void PremultiplyBitmap( HBITMAP hBitmap, COLORREF rgb )
 {
+	if (hBitmap == NULL) return;
 	BITMAP info;
 	GetObject(hBitmap,sizeof(info),&info);
 	int n=info.bmWidth*info.bmHeight;


### PR DESCRIPTION
Blind attempt to eliminate a crash which seems to occur when PremultiplyBitmap() is called after LoadImage() fails.

I'm hoping this might fix the issue reported here: https://github.com/Open-Shell/Open-Shell-Menu/issues/400

Note I haven't been able to test yet, as a) I don't have a build environment, and b) it can take several days/weeks to recreate the issue.