### PR TITLE
Display monochrome icons using color of corresponding text item

### DIFF
--- a/Src/StartMenu/StartMenuDLL/ItemManager.cpp
+++ b/Src/StartMenu/StartMenuDLL/ItemManager.cpp
@@ -176,6 +176,27 @@ static void CreateMonochromeImage( unsigned int *bits, int stride, int width, in
 	}
 }
 
+HBITMAP ColorizeMonochromeImage(HBITMAP bitmap, DWORD color)
+{
+	{
+		BITMAP info{};
+		GetObject(bitmap, sizeof(info), &info);
+		if (!DetectGrayscaleImage((const unsigned int*)info.bmBits, info.bmWidth, info.bmWidth, info.bmHeight))
+			return nullptr;
+	}
+
+	HBITMAP bmp = (HBITMAP)CopyImage(bitmap, IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION);
+	if (bmp)
+	{
+		BITMAP info{};
+		GetObject(bmp, sizeof(info), &info);
+
+		CreateMonochromeImage((unsigned int*)info.bmBits, info.bmWidth, info.bmWidth, info.bmHeight, color);
+	}
+
+	return bmp;
+}
+
 static HBITMAP BitmapFromMetroIcon( HICON hIcon, int bitmapSize, int iconSize, DWORD metroColor, bool bDestroyIcon=true )
 {
 	ICONINFO info;

--- a/Src/StartMenu/StartMenuDLL/ItemManager.h
+++ b/Src/StartMenu/StartMenuDLL/ItemManager.h
@@ -467,6 +467,7 @@ bool MenuGetFileTimestamp( const wchar_t *path, FILETIME *pWriteTime, FILETIME *
 STDAPI ShGetKnownFolderPath( REFKNOWNFOLDERID rfid, PWSTR *pPath );
 STDAPI ShGetKnownFolderIDList(REFKNOWNFOLDERID rfid, PIDLIST_ABSOLUTE *pPidl );
 STDAPI ShGetKnownFolderItem(REFKNOWNFOLDERID rfid, IShellItem **ppItem );
+HBITMAP ColorizeMonochromeImage(HBITMAP bitmap, DWORD color);
 
 #define TASKBAR_PINNED_ROOT L"%APPDATA%\\Microsoft\\Internet Explorer\\Quick Launch\\User Pinned\\TaskBar"
 #define START_MENU_PINNED_ROOT L"%APPDATA%\\OpenShell\\Pinned"

--- a/Src/StartMenu/StartMenuDLL/MenuPaint.cpp
+++ b/Src/StartMenu/StartMenuDLL/MenuPaint.cpp
@@ -2200,6 +2200,21 @@ void CMenuContainer::DrawBackground( HDC hdc, const RECT &drawRect )
 		else
 			iconSize.cx=iconSize.cy=0;
 
+		COLORREF color, shadowColor;
+		{
+			bool bHotColor = (bHot && !bSplit) || stateLeft > 0;
+			if (item.id == MENU_EMPTY || item.id == MENU_EMPTY_TOP)
+			{
+				color = settings.textColors[bHotColor ? 3 : 2];
+				shadowColor = settings.textShadowColors[bHotColor ? 3 : 2];
+			}
+			else
+			{
+				color = settings.textColors[bHotColor ? 1 : 0];
+				shadowColor = settings.textShadowColors[bHotColor ? 1 : 0];
+			}
+		}
+
 		// draw icon
 		if (drawType==MenuSkin::PROGRAMS_BUTTON || drawType==MenuSkin::PROGRAMS_BUTTON_NEW)
 		{
@@ -2256,15 +2271,21 @@ void CMenuContainer::DrawBackground( HDC hdc, const RECT &drawRect )
 			const CItemManager::IconInfo *pIcon=(settings.iconSize==MenuSkin::ICON_SIZE_LARGE)?item.pItemInfo->largeIcon:item.pItemInfo->smallIcon;
 			if (pIcon && pIcon->bitmap)
 			{
+				HBITMAP temp = ColorizeMonochromeImage(pIcon->bitmap, color);
+				HBITMAP bitmap = temp ? temp : pIcon->bitmap;
+
 				BITMAP info;
-				GetObject(pIcon->bitmap,sizeof(info),&info);
-				HGDIOBJ bmp0=SelectObject(hdc2,pIcon->bitmap);
+				GetObject(bitmap,sizeof(info),&info);
+				HGDIOBJ bmp0=SelectObject(hdc2,bitmap);
 				if (bmp0)
 				{
 					BLENDFUNCTION func={AC_SRC_OVER,0,255,AC_SRC_ALPHA};
 					AlphaBlend(hdc,iconX,iconY,iconSize.cx,iconSize.cy,hdc2,0,0,info.bmWidth,info.bmHeight,func);
 					SelectObject(hdc2,bmp0);
 				}
+
+				if (temp)
+					DeleteObject(temp);
 			}
 		}
 		else if (item.id==MENU_SHUTDOWN_BUTTON && s_bHasUpdates && s_Skin.Shutdown_bitmap.GetBitmap())
@@ -2287,18 +2308,6 @@ void CMenuContainer::DrawBackground( HDC hdc, const RECT &drawRect )
 
 		// draw text
 		SelectObject(hdc,settings.font);
-		COLORREF color, shadowColor;
-		bool bHotColor=(bHot && !bSplit) || stateLeft>0;
-		if (item.id==MENU_EMPTY || item.id==MENU_EMPTY_TOP)
-		{
-			color=settings.textColors[bHotColor?3:2];
-			shadowColor=settings.textShadowColors[bHotColor?3:2];
-		}
-		else
-		{
-			color=settings.textColors[bHotColor?1:0];
-			shadowColor=settings.textShadowColors[bHotColor?1:0];
-		}
 		RECT rc={itemRect.left+settings.iconPadding.left+settings.iconPadding.right+settings.textPadding.left,itemRect.top+settings.textPadding.top,
 		         itemRect.right-settings.arrPadding.cx-settings.arrPadding.cy-settings.textPadding.right,itemRect.bottom-settings.textPadding.bottom};
 		if (item.id==MENU_SHUTDOWN_BUTTON)


### PR DESCRIPTION
Some icons (modern settings, jump-list tasks) are monochrome, basically
they are defined just by alpha channel.
Thus they can be displayed in any color (white is default).

Since these icons are white by default, they look nice on dark
backgrounds. But they are not very visible on light backgrounds.

Thus the idea is to 'colorize' such icon using color of corresponding
text item. That way they will always have proper color.

Fixes #466.