### PR TITLE
Metro skin right-hand alignment with Icon Frames

### DIFF
--- a/Src/Skins/Metro/SkinDescription.txt
+++ b/Src/Skins/Metro/SkinDescription.txt
@@ -182,6 +182,8 @@ Main_icon_frame_slices_Y=4,4,4
 Main_icon_frame_offset=3,3
 Main_icon_padding=6,6,6,6,100%
 Main_text_padding=5,2,8,2,100%
+
+[ICON_FRAMES AND NOT SMALL_ICONS AND NOT NO_ICONS]
 Main2_icon_padding=6,6,6,6,100%
 Main2_text_padding=5,2,8,2,100%
 


### PR DESCRIPTION
This should improve the right-hand spacing when icon frames are enabled, and right-hand icons are disabled. There shouldn't be any extra icon/text padding for Main2 when icons aren't enabled.