### PR TITLE
StartMenuButton: Don't overflow taskbar height when img height larger than it

### DIFF
--- a/Src/Lib/ResourceHelper.cpp
+++ b/Src/Lib/ResourceHelper.cpp
@@ -384,7 +384,7 @@ HICON CreateDisabledIcon( HICON hIcon, int iconSize )
 }
 
 // Loads an image file into a bitmap and optionally resizes it
-HBITMAP LoadImageFile( const wchar_t *path, const SIZE *pSize, bool bUseAlpha, bool bPremultiply, std::vector<unsigned int> *pButtonAnim )
+HBITMAP LoadImageFile( const wchar_t *path, const SIZE *pSize, bool bUseAlpha, bool bPremultiply, std::vector<unsigned int> *pButtonAnim, const SIZE *maxSize)
 {
 	HBITMAP srcBmp=NULL;
 	if (_wcsicmp(PathFindExtension(path),L".bmp")==0)
@@ -476,8 +476,19 @@ HBITMAP LoadImageFile( const wchar_t *path, const SIZE *pSize, bool bUseAlpha, b
 			frameWidthD=abs(pSize->cx);
 			if (pSize->cy)
 				frameHeightD=pSize->cy;
+			else if (maxSize && maxSize->cy > 0)
+			{
+				float aspectRatio = (float)frameWidthS / (float)frameHeightS;
+				frameHeightD = frameWidthD * frameHeightS / frameWidthS;
+				if (frameHeightD > maxSize->cy) {
+					frameHeightD = maxSize->cy;
+					frameWidthD = frameHeightD * aspectRatio;
+				}
+			}
 			else
-				frameHeightD=frameWidthD*frameHeightS/frameWidthS;
+			{
+				frameHeightD = frameWidthD * frameHeightS / frameWidthS;
+			}
 		}
 	}
 

--- a/Src/Lib/ResourceHelper.h
+++ b/Src/Lib/ResourceHelper.h
@@ -35,7 +35,7 @@ HICON ShExtractIcon( const char *path, int index, int iconSize );
 HBITMAP BitmapFromIcon( HICON hIcon, int iconSize, unsigned int **pBits, bool bDestroyIcon );
 
 // Loads an image file into a bitmap and optionally resizes it
-HBITMAP LoadImageFile( const wchar_t *path, const SIZE *pSize, bool bUseAlpha, bool bPremultiply, std::vector<unsigned int> *pButtonAnim );
+HBITMAP LoadImageFile( const wchar_t *path, const SIZE *pSize, bool bUseAlpha, bool bPremultiply, std::vector<unsigned int> *pButtonAnim, const SIZE *maxSize);
 
 // Loads a bitmap from a IMAGE resource
 HBITMAP LoadImageResource( HMODULE hModule, const wchar_t *name, bool bTopDown, bool bPremultiply );

--- a/Src/StartMenu/StartMenuDLL/ItemManager.cpp
+++ b/Src/StartMenu/StartMenuDLL/ItemManager.cpp
@@ -323,7 +323,7 @@ static HBITMAP BitmapFromMetroBitmap( HBITMAP hBitmap, int bitmapSize, DWORD met
 static HBITMAP LoadMetroBitmap0(const wchar_t *path, int bitmapSize, DWORD metroColor = 0xFFFFFFFF)
 {
 	SIZE size={-bitmapSize,bitmapSize};
-	HBITMAP hBitmap=LoadImageFile(path,&size,true,true,NULL);
+	HBITMAP hBitmap=LoadImageFile(path,&size,true,true,NULL,NULL);
 	if (hBitmap)
 	{
 		if (metroColor==0xFFFFFFFF)
@@ -403,7 +403,7 @@ static HBITMAP LoadMetroBitmap( const wchar_t *location, int bitmapSize, DWORD m
 	if (bFound)
 	{
 		SIZE size={2-bitmapSize,bitmapSize-2};
-		HBITMAP hBitmap=LoadImageFile(path,&size,true,true,NULL);
+		HBITMAP hBitmap=LoadImageFile(path,&size,true,true,NULL,NULL);
 		if (hBitmap)
 			return BitmapFromMetroBitmap(hBitmap,bitmapSize,metroColor);
 	}
@@ -462,7 +462,7 @@ static HBITMAP LoadMetroBitmap2( const wchar_t *location, int bitmapSize, DWORD 
 		if (iconSize>bitmapSize)
 			iconSize=bitmapSize;
 		SIZE size={iconSize,iconSize};
-		HBITMAP hBitmap=LoadImageFile(path,&size,true,true,NULL);
+		HBITMAP hBitmap=LoadImageFile(path,&size,true,true,NULL,NULL);
 		if (hBitmap)
 			return BitmapFromMetroBitmap(hBitmap,bitmapSize,metroColor);
 	}

--- a/Src/StartMenu/StartMenuDLL/MenuPaint.cpp
+++ b/Src/StartMenu/StartMenuDLL/MenuPaint.cpp
@@ -143,9 +143,9 @@ HBITMAP CMenuContainer::LoadUserImage( int size, HBITMAP hMask )
 		LOG_MENU(LOG_OPEN,L"Loading user image: '%s'",path);
 		SIZE s={size,size};
 		if (str.IsEmpty())
-			hBitmap=LoadImageFile(path,&s,false,false,NULL);
+			hBitmap=LoadImageFile(path,&s,false,false,NULL,NULL);
 		else
-			hBitmap=LoadImageFile(path,&s,true,true,NULL);
+			hBitmap=LoadImageFile(path,&s,true,true,NULL,NULL);
 	}
 	if (hBitmap && hMask)
 	{

--- a/Src/StartMenu/StartMenuDLL/SettingsUI.cpp
+++ b/Src/StartMenu/StartMenuDLL/SettingsUI.cpp
@@ -2748,7 +2748,7 @@ void CCustomMenuDlg7::CItemList::SubclassWindow( HWND hWnd, CCustomMenuDlg7 *pOw
 		else
 			size.cx=0;
 		if (size.cx<50) size.cx=50;
-		
+
 		SelectObject(hdc,font0);
 		DeleteDC(hdc);
 		LVCOLUMN column={LVCF_WIDTH|LVCF_TEXT,0,size.cx,(LPWSTR)(LPCWSTR)str};
@@ -3218,7 +3218,7 @@ void CCustomMenuDlg7::CItemList::InsertItem( int index, int copy )
 	ListView_EnsureVisible(m_hWnd,index,FALSE);
 	UpdateItem(index);
 	m_pOwner->SerializeData();
-	
+
 	ListView_SetItemState(m_hWnd,index,LVIS_SELECTED|LVIS_FOCUSED,LVIS_SELECTED|LVIS_FOCUSED);
 	m_Line=index;
 	if (copy<0)
@@ -3993,7 +3993,7 @@ void CMenuStyleDlg::UpdateIcon( bool bForce )
 	SIZE size={-MAX_ICON_SIZE,0};
 	std::vector<unsigned int> buttonAnim;
 	int frames=3;
-	HBITMAP bitmap=LoadImageFile(path,&size,true,false,&buttonAnim);
+	HBITMAP bitmap=LoadImageFile(path,&size,true,false,&buttonAnim,NULL);
 	if (bitmap)
 	{
 		if (!buttonAnim.empty())
@@ -4737,7 +4737,7 @@ void UpdateSettings( void )
 	UpdateSetting(L"UserFiles",CComVariant(bNoDocs?0:1),bNoDocs);
 	UpdateSetting(L"UserDocuments",CComVariant(bNoDocs?0:1),bNoDocs);
 	UpdateSetting(L"UserPictures",CComVariant(bNoDocs?0:1),bNoDocs);
-	
+
 	bool bNoEdit=SHRestricted(REST_NOCHANGESTARMENU)!=0;
 	UpdateSetting(L"EnableDragDrop",CComVariant(bNoEdit?0:1),bNoEdit);
 	UpdateSetting(L"EnableContextMenu",CComVariant(bNoEdit?0:1),bNoEdit);
@@ -4931,7 +4931,7 @@ void UpdateSettings( void )
 	UpdateSetting(L"MenuItems2",CComVariant(g_DefaultStartMenu2),false);
 	{
 		// make games disabled by default if the folder doesn't exist (like on a server)
-		
+
 		const wchar_t *defaultMenu, *gameSettings0, *gameSettings1, *gameSettings2;
 		if (GetWinVersion()<WIN_VER_WIN81)
 		{

--- a/Src/StartMenu/StartMenuDLL/StartButton.cpp
+++ b/Src/StartMenu/StartMenuDLL/StartButton.cpp
@@ -529,7 +529,8 @@ void CStartButton::LoadBitmap( void )
 		std::vector<unsigned int> buttonAnim;
 		if (*path)
 		{
-			m_Bitmap=LoadImageFile(path,&size,true,true,&buttonAnim);
+			SIZE* taskbarSize = GetTaskBarSize(m_TaskbarId);
+			m_Bitmap=LoadImageFile(path,&size,true,true,&buttonAnim,taskbarSize);
 		}
 		if (!m_Bitmap)
 		{

--- a/Src/StartMenu/StartMenuDLL/StartMenuDLL.cpp
+++ b/Src/StartMenu/StartMenuDLL/StartMenuDLL.cpp
@@ -687,6 +687,15 @@ bool PointAroundStartButton( size_t taskbarId, const CPoint &pt )
 		return pt.x<rc.right;
 }
 
+SIZE* GetTaskBarSize(size_t taskbarId)
+{
+	const TaskbarInfo* taskBar = GetTaskbarInfo(taskbarId);
+	RECT rcTask;
+	GetWindowRect(taskBar->taskBar, &rcTask);
+	SIZE *taskbarSize = new SIZE{ rcTask.right - rcTask.left,rcTask.bottom - rcTask.top };
+	return taskbarSize;
+}
+
 // declare few interfaces so we don't need the Win8 SDK
 #ifndef __IAppVisibility_INTERFACE_DEFINED__
 typedef enum MONITOR_APP_VISIBILITY

--- a/Src/StartMenu/StartMenuDLL/StartMenuDLL.h
+++ b/Src/StartMenu/StartMenuDLL/StartMenuDLL.h
@@ -73,6 +73,7 @@ struct TaskbarInfo
 };
 
 TaskbarInfo *GetTaskbarInfo( size_t taskbarId );
+SIZE *GetTaskBarSize( size_t taskbarId );
 UINT GetTaskbarPosition( HWND taskBar, MONITORINFO *pInfo, HMONITOR *pMonitor, RECT *pRc );
 
 extern HWND STARTMENUAPI g_TaskBar, g_OwnerWindow;


### PR DESCRIPTION
### Motivation

Currently I have 2 screens, one has less pixels than the other. So a custom start menu image has this issue:

Screen 1
![Screen 1](https://user-images.githubusercontent.com/14908759/147888606-1cd73e28-8be6-4248-8412-586a3241dd1c.png)

Screen 2
![HBxRsOJE3B](https://user-images.githubusercontent.com/14908759/147888620-a7793c13-0342-4960-9d91-dc5feb3b7008.png)

The problem arises when I have to make the button fit in the second screen. When manually setting the start menu width to 200px, this happens:

Screen 1
![NVIDIA_Share_G6FHQ7nYjz](https://user-images.githubusercontent.com/14908759/147888641-69f234e2-d0dc-4650-9044-21118305e770.png)

Screen 2
![SM4yriESUM](https://user-images.githubusercontent.com/14908759/147888644-8f8ce227-78fa-4ecd-9059-44f963f937bd.png)

**There should be a way to fit the start men icon in the two screens**.


### The fix

When start menu button resized size y > task bar height, fit it accordingly. This is the two screens after button width = 200px and my fix is applied:

 Screen 1
![NOnYa7gXH0](https://user-images.githubusercontent.com/14908759/147888718-49e6db71-8d23-4139-bb0d-d233676d52da.png)

Screen 2
![lbfJYtgguw](https://user-images.githubusercontent.com/14908759/147888720-0d31dbcb-ebbd-4024-9e84-02a57b845bcf.png)

