### PR TITLE
Fix corrupted icons in second column

### DIFF
--- a/Src/StartMenu/StartMenuDLL/MenuContainer.cpp
+++ b/Src/StartMenu/StartMenuDLL/MenuContainer.cpp
@@ -1084,7 +1084,8 @@ void CMenuContainer::AddStandardItems( void )
 			if (m_bSubMenu && pStdItem->id==s_ShutdownCommand)
 				continue;
 
-			if (pStdItem->id==MENU_COLUMN_BREAK && m_bTwoColumns)
+			const bool bTwoColumns = (!m_bSubMenu && s_Skin.TwoColumns);
+			if (pStdItem->id==MENU_COLUMN_BREAK && bTwoColumns)
 				mainIconSize=s_Skin.Main2_icon_size;
 
 			int stdOptions=GetStdOptions(pStdItem->id);


### PR DESCRIPTION
When using skin with a different second column icon size, all of the
icons in it would become blank.

Because m_bTwoColumns is set after AddStandardItems, it is still false
in the column break check. As a workaround, use the value it's assigned
later in InitWindowInternal instead.

Fix Open-Shell/Open-Shell-Menu#980