### PR TITLE
Restore Main_no_icons2 behavior for inline subitems

### DIFF
--- a/Src/StartMenu/StartMenuDLL/MenuContainer.cpp
+++ b/Src/StartMenu/StartMenuDLL/MenuContainer.cpp
@@ -1071,7 +1071,7 @@ void CMenuContainer::AddStandardItems( void )
 		const StdMenuItem *pInlineParent=NULL;
 		int searchProviderIndex=-1;
 		m_SearchProvidersCount=0;
-		bool bSecondColumn = false;
+		bool bSecondColumn=false;
 		for (const StdMenuItem *pStdItem=m_pStdItem;;pStdItem++)
 		{
 			if (pStdItem->id==MENU_LAST)
@@ -1090,7 +1090,7 @@ void CMenuContainer::AddStandardItems( void )
 				continue;
 
 			if (pStdItem->id==MENU_COLUMN_BREAK && !m_bSubMenu && s_Skin.TwoColumns)
-				bSecondColumn = true;
+				bSecondColumn=true;
 
 			int stdOptions=GetStdOptions(pStdItem->id);
 			if (!(stdOptions&MENU_ENABLED)) continue;
@@ -1273,7 +1273,7 @@ void CMenuContainer::AddStandardItems( void )
 			// get icon
 			MenuSkin::TIconSize mainIconSize = s_Skin.Main_icon_size;
 			if (bSecondColumn && !item.bInline)
-				mainIconSize = s_Skin.Main2_icon_size;
+				mainIconSize=s_Skin.Main2_icon_size;
 			
 			CItemManager::TIconSizeType iconSizeType;
 			int refreshFlags;

--- a/Src/StartMenu/StartMenuDLL/MenuContainer.cpp
+++ b/Src/StartMenu/StartMenuDLL/MenuContainer.cpp
@@ -1071,7 +1071,7 @@ void CMenuContainer::AddStandardItems( void )
 		const StdMenuItem *pInlineParent=NULL;
 		int searchProviderIndex=-1;
 		m_SearchProvidersCount=0;
-		MenuSkin::TIconSize mainIconSize=s_Skin.Main_icon_size;
+		bool bSecondColumn = false;
 		for (const StdMenuItem *pStdItem=m_pStdItem;;pStdItem++)
 		{
 			if (pStdItem->id==MENU_LAST)
@@ -1089,9 +1089,8 @@ void CMenuContainer::AddStandardItems( void )
 			if (m_bSubMenu && pStdItem->id==s_ShutdownCommand)
 				continue;
 
-			const bool bTwoColumns = (!m_bSubMenu && s_Skin.TwoColumns);
-			if (pStdItem->id==MENU_COLUMN_BREAK && bTwoColumns)
-				mainIconSize=s_Skin.Main2_icon_size;
+			if (pStdItem->id==MENU_COLUMN_BREAK && !m_bSubMenu && s_Skin.TwoColumns)
+				bSecondColumn = true;
 
 			int stdOptions=GetStdOptions(pStdItem->id);
 			if (!(stdOptions&MENU_ENABLED)) continue;
@@ -1272,9 +1271,9 @@ void CMenuContainer::AddStandardItems( void )
 			item.bSplit=item.bFolder && (item.pStdItem->settings&StdMenuItem::MENU_SPLIT_BUTTON)!=0;
 
 			// get icon
-			const MenuSkin::TIconSize mainIconSizeOrig=mainIconSize;
-			if (item.bInline && mainIconSize==MenuSkin::ICON_SIZE_NONE)
-				mainIconSize=s_Skin.Main_icon_size;
+			MenuSkin::TIconSize mainIconSize = s_Skin.Main_icon_size;
+			if (bSecondColumn && !item.bInline)
+				mainIconSize = s_Skin.Main2_icon_size;
 			
 			CItemManager::TIconSizeType iconSizeType;
 			int refreshFlags;
@@ -1331,8 +1330,6 @@ void CMenuContainer::AddStandardItems( void )
 			}
 			else
 				item.pItemInfo=g_ItemManager.GetCustomIcon(NULL,iconSizeType);
-
-			mainIconSize=mainIconSizeOrig;
 
 			// get name
 			if (pStdItem->label && _wcsicmp(pStdItem->label,L"none")==0)

--- a/Src/StartMenu/StartMenuDLL/MenuContainer.cpp
+++ b/Src/StartMenu/StartMenuDLL/MenuContainer.cpp
@@ -1271,9 +1271,9 @@ void CMenuContainer::AddStandardItems( void )
 			item.bSplit=item.bFolder && (item.pStdItem->settings&StdMenuItem::MENU_SPLIT_BUTTON)!=0;
 
 			// get icon
-			MenuSkin::TIconSize mainIconSize = s_Skin.Main_icon_size;
-			if (bSecondColumn && !item.bInline)
-				mainIconSize=s_Skin.Main2_icon_size;
+			MenuSkin::TIconSize mainIconSize=!bSecondColumn ? s_Skin.Main_icon_size : s_Skin.Main2_icon_size;
+			if (item.bInline && mainIconSize==MenuSkin::ICON_SIZE_NONE)
+				mainIconSize=s_Skin.Main_icon_size;
 			
 			CItemManager::TIconSizeType iconSizeType;
 			int refreshFlags;

--- a/Src/StartMenu/StartMenuDLL/MenuContainer.cpp
+++ b/Src/StartMenu/StartMenuDLL/MenuContainer.cpp
@@ -1272,6 +1272,10 @@ void CMenuContainer::AddStandardItems( void )
 			item.bSplit=item.bFolder && (item.pStdItem->settings&StdMenuItem::MENU_SPLIT_BUTTON)!=0;
 
 			// get icon
+			const MenuSkin::TIconSize mainIconSizeOrig=mainIconSize;
+			if (item.bInline && mainIconSize==MenuSkin::ICON_SIZE_NONE)
+				mainIconSize=s_Skin.Main_icon_size;
+			
 			CItemManager::TIconSizeType iconSizeType;
 			int refreshFlags;
 			if (bSearchProvider7 || m_bSubMenu)
@@ -1327,6 +1331,8 @@ void CMenuContainer::AddStandardItems( void )
 			}
 			else
 				item.pItemInfo=g_ItemManager.GetCustomIcon(NULL,iconSizeType);
+
+			mainIconSize=mainIconSizeOrig;
 
 			// get name
 			if (pStdItem->label && _wcsicmp(pStdItem->label,L"none")==0)


### PR DESCRIPTION
Fix regression caused by b89aaed7854212926729aabb4a05d5b517cb5549.
https://github.com/Open-Shell/Open-Shell-Menu/pull/1088#issuecomment-1273959550

The original commit fixed a bug where the icons would not be generated for the second column's icon size. However, the bugged behavior had masked a discrepancy between the icons generated for the inlined submenus (inserted as buttons) in CMenuContainer::AddStandardItems and the drawing settings for them in MenuSkin::LoadSkin. Here are the snippets in order:

https://github.com/Open-Shell/Open-Shell-Menu/blob/e6b33a70e4230d30ceff2ccc4eaf7c3be271f456/Src/StartMenu/StartMenuDLL/MenuContainer.cpp#L1275-L1305
https://github.com/Open-Shell/Open-Shell-Menu/blob/e6b33a70e4230d30ceff2ccc4eaf7c3be271f456/Src/StartMenu/StartMenuDLL/SkinManager.cpp#L2932-L2933

Since previously mainIconSize was always equal to Main_icon_size (first column's icons), the correct icons were created for the subitems. This workaround restores the old, more correct behavior by saving mainIconSize and restoring it after the related code is over.

Maybe a more permanent solution is to refactor the icon code to run after AddStandardItems, when we know about the icon sizes for each item?