### PR TITLE
Setup: Don't install Classic IE by default

### DIFF
--- a/Src/Setup/Setup.wxs
+++ b/Src/Setup/Setup.wxs
@@ -103,7 +103,6 @@
 				<ComponentRef Id="ClassicIE_64.exe" />
 				<?endif ?>
 				<ComponentRef Id="IESettingsLink" />
-				<Condition Level="1">IE_BUILD&gt;=90000</Condition>
 			</Feature>
 			<Feature Id="Update" Level="1" Title="!(loc.UpdateTitle)" ConfigurableDirectory="APPLICATIONFOLDER" AllowAdvertise="no" Description="!(loc.UpdateDesc)">
 				<ComponentRef Id="Update.exe" />


### PR DESCRIPTION
IE was deprecated long ago. There is no need to install Classic IE by default.
Users will be still able to install it if they want.