### PR TITLE
Avoid recursive Start menu initialization (#1675)

### DIFF
--- a/Src/StartMenu/StartMenuDLL/StartMenuDLL.cpp
+++ b/Src/StartMenu/StartMenuDLL/StartMenuDLL.cpp
@@ -2891,6 +2891,12 @@ static void OpenCortana( void )
 
 static void InitStartMenuDLL( void )
 {
+	static bool initCalled = false;
+	if (initCalled)
+		return;
+
+	initCalled = true;
+
 	LogToFile(STARTUP_LOG, L"StartMenu DLL: InitStartMenuDLL");
 	WaitDllInitThread();
 


### PR DESCRIPTION
It may happen that during `InitStartMenuDLL` execution some component posts a message that is then intercepted by (still active) `HookInject` that will call `InitStartMenuDLL` again (and everything will repeat).

To prevent such endless recursion during initialization, we will make sure that `InitStartMenuDLL` will be executed just once.