### PR TITLE
Fix start button/menu misalignment on touch-screen devices

### DIFF
--- a/Src/BUILDME.txt
+++ b/Src/BUILDME.txt
@@ -10,7 +10,7 @@ Visual Studio 2022 (Community Edition is enough)
   - Windows 11 SDK (10.0.22621.0) for Desktop C++
   - Visual C++ ATL support
 HTML Help Workshop
-WiX 3.11
+WiX 3.14
 7-Zip
 It is possible to convert the projects to newer versions of Visual Studio and newer SDKs.
 Newer versions of WiX will probably work fine.

--- a/Src/Setup/__MakeFinal.bat
+++ b/Src/Setup/__MakeFinal.bat
@@ -1,5 +1,5 @@
 @echo off
-set PATH=C:\Program Files\7-Zip\;C:\Program Files (x86)\HTML Help Workshop;C:\Program Files (x86)\WiX Toolset v3.11\bin\;%PATH%
+set PATH=C:\Program Files\7-Zip\;C:\Program Files (x86)\HTML Help Workshop;C:\Program Files (x86)\WiX Toolset v3.14\bin\;%PATH%
 
 cd %~dp0
 

--- a/Src/Setup/__MakeFinalAllLanguages.bat
+++ b/Src/Setup/__MakeFinalAllLanguages.bat
@@ -1,7 +1,7 @@
 @echo off
 rem This file is to create all the files required for a new release to publish
 
-set PATH=C:\Program Files\7-Zip\;C:\Program Files (x86)\HTML Help Workshop;C:\Program Files (x86)\WiX Toolset v3.11\bin\;%PATH%
+set PATH=C:\Program Files\7-Zip\;C:\Program Files (x86)\HTML Help Workshop;C:\Program Files (x86)\WiX Toolset v3.14\bin\;%PATH%
 
 cd %~dp0
 

--- a/Src/StartMenu/StartMenuDLL/StartMenuDLL.cpp
+++ b/Src/StartMenu/StartMenuDLL/StartMenuDLL.cpp
@@ -603,6 +603,11 @@ UINT GetTaskbarPosition( HWND taskBar, MONITORINFO *pInfo, HMONITOR *pMonitor, R
 		SHAppBarMessage(ABM_GETTASKBARPOS,&appbar);
 		if (pRc)
 		{
+			if (RECT rc; GetWindowRgnBox(taskBar,&rc)!=ERROR)
+			{
+				MapWindowPoints(taskBar,NULL,(POINT*)&rc,2);
+				appbar.rc=rc;
+			}
 			*pRc=appbar.rc;
 			RECT rc;
 			GetWindowRect(taskBar,&rc);
@@ -1217,9 +1222,8 @@ static void UpdateStartButtonPosition(const TaskbarInfo* taskBar, const WINDOWPO
 		RecreateStartButton(taskBar->taskbarId);
 
 	RECT rcTask;
-	GetWindowRect(taskBar->taskBar, &rcTask);
 	MONITORINFO info;
-	UINT uEdge = GetTaskbarPosition(taskBar->taskBar, &info, NULL, NULL);
+	UINT uEdge = GetTaskbarPosition(taskBar->taskBar, &info, NULL, &rcTask);
 	DWORD buttonFlags = SWP_NOACTIVATE | SWP_NOOWNERZORDER | SWP_NOSIZE;
 	if (IsWindowVisible(taskBar->taskBar))
 		buttonFlags |= SWP_SHOWWINDOW;


### PR DESCRIPTION
Windows 11 22H2 introduced new touch-optimized taskbar for devices with touch screen.

It seems that in this mode taskbar window size is bigger than actual taskbar on screen. There is region defined for the window that covers actually displayed portion of the window.

We should account for that region (if present) when obtaining taskbar window dimensions.

More info about how to enable/disable touch taskbar: https://www.elevenforum.com/t/turn-on-or-off-tablet-optimized-taskbar-in-windows-11.5133/