### PR TITLE
Make `FixFolderScroll` available in all Windows versions

### DIFF
--- a/Src/ClassicExplorer/ExplorerBHO.cpp
+++ b/Src/ClassicExplorer/ExplorerBHO.cpp
@@ -243,7 +243,7 @@ LRESULT CALLBACK CExplorerBHO::HookExplorer( int nCode, WPARAM wParam, LPARAM lP
 			if (GetClassName(parent,name,_countof(name)) && _wcsicmp(name,L"CabinetWClass")==0)
 			{
 				DWORD_PTR settings=0;
-				if (GetWinVersion()==WIN_VER_WIN7 && GetSettingBool(L"FixFolderScroll"))
+				if (GetSettingBool(L"FixFolderScroll"))
 					settings|=1;
 				SetWindowSubclass(hWnd,SubclassTreeProc,'CLSH',settings);
 				PostMessage(hWnd,TVM_SETEXTENDEDSTYLE,TVS_EX_FADEINOUTEXPANDOS|TVS_EX_AUTOHSCROLL|0x80000000,0);

--- a/Src/ClassicExplorer/SettingsUI.cpp
+++ b/Src/ClassicExplorer/SettingsUI.cpp
@@ -621,7 +621,7 @@ void UpdateSettings( void )
 
 		UpdateSetting(L"ShowCaption",CComVariant(0),false); HideSetting(L"ShowCaption",true);
 		UpdateSetting(L"ShowIcon",CComVariant(0),false); HideSetting(L"ShowIcon",true);
-		UpdateSetting(L"FixFolderScroll",CComVariant(0),false); HideSetting(L"FixFolderScroll",true);
+		UpdateSetting(L"FixFolderScroll",CComVariant(0),false);
 		UpdateSetting(L"ToolbarItems",CComVariant(g_DefaultToolbar2),false);
 
 		if (GetWinVersion()>=WIN_VER_WIN10)


### PR DESCRIPTION
It was available only for Win7.
But it seems to work/help also on Win8/10.

Fixes #1885.