### PR TITLE
Cleanup for Vista related code in the compile time. Cleanup copy-past from Windows SDK. It's probably fix for issues related to the Windows 7. Improve compilation time.

### DIFF
--- a/Src/ClassicExplorer/ClassicCopy.cpp
+++ b/Src/ClassicExplorer/ClassicCopy.cpp
@@ -687,7 +687,7 @@ static LRESULT CALLBACK WindowProc( HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM 
 						if (bDef)
 						{
 							delay=0;
-							if (GetWinVersion()>=WIN_VER_WIN7)
+							if (GetWinVersion()>=_WIN32_WINNT_WIN7)
 							{
 								BOOL comp;
 								if (SUCCEEDED(DwmIsCompositionEnabled(&comp)) && comp)

--- a/Src/ClassicExplorer/ClassicCopyExt.cpp
+++ b/Src/ClassicExplorer/ClassicCopyExt.cpp
@@ -38,7 +38,7 @@ STDMETHODIMP CClassicCopyExt::InvokeCommand( LPCMINVOKECOMMANDINFO pCmdInfo )
 
 HRESULT WINAPI CClassicCopyExt::UpdateRegistry( BOOL bRegister )
 {
-	if (GetWinVersion()>=WIN_VER_WIN8)
+	if (GetWinVersion()>=_WIN32_WINNT_WIN8)
 		return S_OK;
 	return _AtlModule.UpdateRegistryFromResource(IDR_CLASSICCOPYEXT,bRegister);
 }

--- a/Src/ClassicExplorer/ClassicExplorerSettings/ClassicExplorerSettings.cpp
+++ b/Src/ClassicExplorer/ClassicExplorerSettings/ClassicExplorerSettings.cpp
@@ -2,6 +2,9 @@
 // Open-Shell (c) 2017-2018, The Open-Shell Team
 // Confidential information of Ivo Beltchev. Not for disclosure or distribution without prior written consent from the author
 
+#define WIN32_LEAN_AND_MEAN
+#define VC_EXTRALEAN
+#define NOMINMAX
 #include <windows.h>
 #include <commctrl.h>
 #include <shlwapi.h>

--- a/Src/ClassicExplorer/ExplorerBHO.cpp
+++ b/Src/ClassicExplorer/ExplorerBHO.cpp
@@ -156,7 +156,7 @@ LRESULT CALLBACK CExplorerBHO::SubclassTreeProc( HWND hWnd, UINT uMsg, WPARAM wP
 			indent=0;
 
 		int treeStyle=GetSettingInt(L"TreeStyle");
-		if (treeStyle==STYLE_CLASSIC && GetWinVersion()>=WIN_VER_WIN10)
+		if (treeStyle==STYLE_CLASSIC && GetWinVersion()>= _WIN32_WINNT_WIN10)
 			treeStyle=STYLE_VISTA;
 		DWORD style=GetWindowLong(hWnd,GWL_STYLE);
 		if (treeStyle!=STYLE_VISTA)
@@ -209,7 +209,7 @@ LRESULT CALLBACK CExplorerBHO::SubclassTreeProc( HWND hWnd, UINT uMsg, WPARAM wP
 		if (GetSettingBool(L"FullIndent"))
 			indent=0;
 
-		if (GetSettingInt(L"TreeStyle")==STYLE_CLASSIC && GetWinVersion()<WIN_VER_WIN10)
+		if (GetSettingInt(L"TreeStyle")==STYLE_CLASSIC && GetWinVersion()< _WIN32_WINNT_WIN10)
 		{
 			HIMAGELIST images=TreeView_GetImageList(hWnd,TVSIL_NORMAL);
 			int cx, cy;
@@ -1109,7 +1109,7 @@ HRESULT STDMETHODCALLTYPE CExplorerBHO::SetSite( IUnknown *pUnkSite )
 					SetProp(m_TopWindow,g_LoadedSettingsAtom,(HANDLE)1);
 					LoadSettings();
 				}
-				bool bWin8=(GetWinVersion()>=WIN_VER_WIN8);
+				bool bWin8=(GetWinVersion()>= _WIN32_WINNT_WIN8);
 
 				m_UpButtonIndex=bWin8?0:GetSettingInt(L"ShowUpButton");
 				bool bShowCaption=!bWin8 && GetSettingBool(L"ShowCaption");

--- a/Src/ClassicExplorer/ExplorerBand.cpp
+++ b/Src/ClassicExplorer/ExplorerBand.cpp
@@ -539,7 +539,7 @@ static bool GetPidlPath( PIDLIST_ABSOLUTE pidl, wchar_t *path )
 	path[0]=0;
 	if (SHGetPathFromIDList(pidl,path) && *path)
 		return true;
-	if (GetWinVersion()>=WIN_VER_WIN7)
+	if (GetWinVersion()>= _WIN32_WINNT_WIN7)
 	{
 		// maybe it is a library - try the default save folder
 		CComPtr<IShellItem> pShellItem;
@@ -1747,7 +1747,7 @@ void CBandWindow::UpdateToolbar( void )
 
 				if (m_pBrowserBag)
 				{
-					if (GetWinVersion()>=WIN_VER_WIN8)
+					if (GetWinVersion()>= _WIN32_WINNT_WIN8)
 					{
 						VARIANT val={VT_EMPTY};
 						if (SUCCEEDED(m_pBrowserBag->Read(g_ComboPaneEnabled,&val,NULL)) && val.vt==VT_BOOL && !val.boolVal)
@@ -1983,7 +1983,7 @@ void CBandWindow::SetBrowsers( IShellBrowser *pBrowser, IWebBrowser2 *pWebBrowse
 
 CExplorerBand::CExplorerBand( void )
 {
-	m_bSubclassRebar=GetWinVersion()>=WIN_VER_WIN7;
+	m_bSubclassRebar=GetWinVersion()>= _WIN32_WINNT_WIN7;
 	m_bSubclassedRebar=false;
 	m_TopWindow=NULL;
 }

--- a/Src/ClassicExplorer/SettingsUI.cpp
+++ b/Src/ClassicExplorer/SettingsUI.cpp
@@ -252,7 +252,7 @@ private:
 
 LRESULT CEditToolbarDlg::OnInitDialog( UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled )
 {
-	m_Style=GetWinVersion()>=WIN_VER_WIN8?SETTINGS_STYLE_WIN8:SETTINGS_STYLE_WIN7;
+	m_Style=GetWinVersion()>=_WIN32_WINNT_WIN8?SETTINGS_STYLE_WIN8:SETTINGS_STYLE_WIN7;
 	CWindow commands=GetDlgItem(IDC_COMBOCOMMAND);
 	CWindow links=GetDlgItem(IDC_COMBOLINK);
 	InitDialog(commands,g_StdCommands,m_Style,SETTINGS_STYLE_MASK,links,g_CommonLinks);
@@ -428,7 +428,7 @@ LRESULT CEditToolbarDlg::OnReset( WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL
 class CCustomToolbarDlg: public CCustomTreeDlg
 {
 public:
-	CCustomToolbarDlg( void ): CCustomTreeDlg(false,g_StdCommands,GetWinVersion()>=WIN_VER_WIN8?SETTINGS_STYLE_WIN8:SETTINGS_STYLE_WIN7,SETTINGS_STYLE_MASK) {}
+	CCustomToolbarDlg( void ): CCustomTreeDlg(false,g_StdCommands,GetWinVersion()>=_WIN32_WINNT_WIN8?SETTINGS_STYLE_WIN8:SETTINGS_STYLE_WIN7,SETTINGS_STYLE_MASK) {}
 
 protected:
 	virtual void ParseTreeItemExtra( CTreeItem *pItem, CSettingsParser &parser );
@@ -604,7 +604,7 @@ void UpdateSettings( void )
 	UpdateSetting(L"UpIconSize",CComVariant((dpi>=120)?36:30),false);
 	FindSetting(L"UpHotkey2")->pLinkTo=FindSetting(L"UpHotkey");
 
-	if (GetWinVersion()>=WIN_VER_WIN8)
+	if (GetWinVersion()>=_WIN32_WINNT_WIN8)
 	{
 		// Windows 8
 		HideSettingGroup(L"StatusBar",true);
@@ -624,7 +624,7 @@ void UpdateSettings( void )
 		UpdateSetting(L"FixFolderScroll",CComVariant(0),false);
 		UpdateSetting(L"ToolbarItems",CComVariant(g_DefaultToolbar2),false);
 
-		if (GetWinVersion()>=WIN_VER_WIN10)
+		if (GetWinVersion()>=_WIN32_WINNT_WIN10)
 		{
 			FindSetting(L"TreeStyle")[1].flags|=CSetting::FLAG_HIDDEN;
 		}
@@ -657,14 +657,14 @@ static bool g_bCopyHook0; // initial state of the copy hook before the settings 
 void InitSettings( void )
 {
 	InitSettings(g_Settings,COMPONENT_EXPLORER,NULL);
-	g_bCopyHook0=GetWinVersion()<WIN_VER_WIN8 && (GetSettingBool(L"ReplaceFileUI") || GetSettingBool(L"ReplaceFolderUI") || GetSettingBool(L"EnableMore"));
+	g_bCopyHook0=GetWinVersion()< _WIN32_WINNT_WIN8 && (GetSettingBool(L"ReplaceFileUI") || GetSettingBool(L"ReplaceFolderUI") || GetSettingBool(L"EnableMore"));
 }
 
 void ClosingSettings( HWND hWnd, int flags, int command )
 {
 	if (command==IDOK)
 	{
-		bool bCopyHook=GetWinVersion()<WIN_VER_WIN8 && (GetSettingBool(L"ReplaceFileUI") || GetSettingBool(L"ReplaceFolderUI") || GetSettingBool(L"EnableMore"));
+		bool bCopyHook=GetWinVersion()< _WIN32_WINNT_WIN8 && (GetSettingBool(L"ReplaceFileUI") || GetSettingBool(L"ReplaceFolderUI") || GetSettingBool(L"EnableMore"));
 
 		if ((flags&CSetting::FLAG_COLD) || (bCopyHook && !g_bCopyHook0))
 			MessageBox(hWnd,LoadStringEx(IDS_NEW_SETTINGS2),LoadStringEx(IDS_APP_TITLE),MB_OK|MB_ICONWARNING);

--- a/Src/ClassicExplorer/dllmain.cpp
+++ b/Src/ClassicExplorer/dllmain.cpp
@@ -169,7 +169,7 @@ extern "C" BOOL WINAPI DllMain( HINSTANCE hInstance, DWORD dwReason, LPVOID lpRe
 		const wchar_t *exe=PathFindFileName(path);
 		g_bExplorerExe=(_wcsicmp(exe,L"explorer.exe")==0 || _wcsicmp(exe,L"verclsid.exe")==0);
 		bool bReplaceUI=false;
-		if (GetWinVersion()<=WIN_VER_WIN7)
+		if (GetWinVersion()<=_WIN32_WINNT_WIN7)
 		{
 			settings[SETTING_REPLACE_FILE].LoadValue(regSettings,regSettingsUser,regPolicy,regPolicyUser);
 			settings[SETTING_REPLACE_FOLDER].LoadValue(regSettings,regSettingsUser,regPolicy,regPolicyUser);

--- a/Src/ClassicExplorer/stdafx.h
+++ b/Src/ClassicExplorer/stdafx.h
@@ -12,6 +12,9 @@
 #define _ATL_NO_AUTOMATIC_NAMESPACE
 #define _ATL_MODULES // compatibility with /permissive-
 #define _ATL_CSTRING_EXPLICIT_CONSTRUCTORS	// some CString constructors will be explicit
+#define VC_EXTRALEAN
+#define NOMINMAX
+#define _ATL_ALL_WARNINGS
 
 #include "resource.h"
 #include <atlbase.h>

--- a/Src/ClassicExplorer/targetver.h
+++ b/Src/ClassicExplorer/targetver.h
@@ -7,18 +7,15 @@
 
 // Modify the following defines if you have to target a platform prior to the ones specified below.
 // Refer to MSDN for the latest info on corresponding values for different platforms.
-#ifndef WINVER                          // Specifies that the minimum required platform is Windows 7.
-#define WINVER 0x0602           // Change this to the appropriate value to target other versions of Windows.
+
+#ifndef _WIN32_WINNT                   // Specifies that the minimum required platform is Windows 7.
+#define _WIN32_WINNT _WIN32_WINNT_WIN7 // Change this to the appropriate value to target other versions of Windows.
 #endif
 
-#ifndef _WIN32_WINNT            // Specifies that the minimum required platform is Windows 7.
-#define _WIN32_WINNT 0x0602     // Change this to the appropriate value to target other versions of Windows.
+#ifndef _WIN32_IE                      // Specifies that the minimum required platform is Internet Explorer 11.0.
+#define _WIN32_IE _WIN32_IE_IE110      // Change this to the appropriate value to target other versions of IE.
 #endif
 
-#ifndef _WIN32_WINDOWS          // Specifies that the minimum required platform is Windows 98.
-#define _WIN32_WINDOWS 0x0410 // Change this to the appropriate value to target Windows Me or later.
-#endif
-
-#ifndef _WIN32_IE                       // Specifies that the minimum required platform is Internet Explorer 7.0.
-#define _WIN32_IE 0x0700        // Change this to the appropriate value to target other versions of IE.
+#ifndef NTDDI_VERSION                  // Specifies that the minimum required platform is NTDDI for Windows 8.
+#define NTDDI_VERSION NTDDI_WIN8       // Change this to the appropriate value to target other versions of NTDDI.
 #endif

--- a/Src/ClassicIE/ClassicIE.cpp
+++ b/Src/ClassicIE/ClassicIE.cpp
@@ -4,6 +4,10 @@
 
 #define STRICT_TYPED_ITEMIDS
 #define _ATL_CSTRING_EXPLICIT_CONSTRUCTORS	// some CString constructors will be explicit
+#define WIN32_LEAN_AND_MEAN
+#define VC_EXTRALEAN
+#define NOMINMAX
+#define _ATL_ALL_WARNINGS
 #include <windows.h>
 #include <commctrl.h>
 #include <shlwapi.h>

--- a/Src/ClassicIE/ClassicIEDLL/DrawCaption.cpp
+++ b/Src/ClassicIE/ClassicIEDLL/DrawCaption.cpp
@@ -152,7 +152,9 @@ static LRESULT CALLBACK SubclassCaptionProc( HWND hWnd, UINT uMsg, WPARAM wParam
 			{
 				// exclude the caption buttons
 				rc.right-=g_SysButtonSize.cx+5;
-				if (GetWinVersion()==WIN_VER_VISTA) rc.bottom++;
+#if _WIN32_WINNT > _WIN32_WINNT_VISTA
+				if (GetWinVersion()==_WIN32_WINNT_VISTA) rc.bottom++;
+#endif
 				if (!bMaximized)
 				{
 					rc.left+=g_CustomCaption[0].leftPadding;
@@ -176,10 +178,10 @@ static LRESULT CALLBACK SubclassCaptionProc( HWND hWnd, UINT uMsg, WPARAM wParam
 						rc.left+=iconSize;
 					}
 					rc.left+=g_CustomCaption[1].iconPadding;
-					if (GetWinVersion()>=WIN_VER_WIN10)
+					if (GetWinVersion()>=_WIN32_WINNT_WIN10)
 						rc.bottom++;
 				}
-				if (GetWinVersion()<WIN_VER_WIN10)
+				if (GetWinVersion()<_WIN32_WINNT_WIN10)
 					rc.top=rc.bottom-g_SysButtonSize.cy;
 				HFONT font0=(HFONT)SelectObject(hdcPaint,font);
 				RECT rcText={0,0,0,0};

--- a/Src/ClassicIE/ClassicIEDLL/SettingsUI.cpp
+++ b/Src/ClassicIE/ClassicIEDLL/SettingsUI.cpp
@@ -51,7 +51,7 @@ void UpgradeSettings( bool bShared )
 
 void UpdateSettings( void )
 {
-	bool bWin8=(GetWinVersion()>=WIN_VER_WIN8);
+	bool bWin8=(GetWinVersion()>=_WIN32_WINNT_WIN8);
 
 	BOOL bComposition=0;
 	if (FAILED(DwmIsCompositionEnabled(&bComposition)))
@@ -75,7 +75,7 @@ void UpdateSettings( void )
 
 	UpdateSetting(L"Glow",CComVariant(bComposition?1:0),false);
 	UpdateSetting(L"MaxGlow",CComVariant(bComposition?1:0),false);
-	UpdateSetting(L"CenterCaption",CComVariant((bWin8 && GetWinVersion()<WIN_VER_WIN10)?1:0),false);
+	UpdateSetting(L"CenterCaption",CComVariant((bWin8 && GetWinVersion()<_WIN32_WINNT_WIN10)?1:0),false);
 
 	// create a dummy window to get a theme
 	HWND hwnd=CreateWindow(L"#32770",L"",WS_OVERLAPPEDWINDOW,0,0,0,0,NULL,NULL,NULL,0);

--- a/Src/ClassicIE/ClassicIEDLL/stdafx.h
+++ b/Src/ClassicIE/ClassicIEDLL/stdafx.h
@@ -15,6 +15,11 @@
 #define _ATL_NO_AUTOMATIC_NAMESPACE
 #define _ATL_MODULES // compatibility with /permissive-
 #define _ATL_CSTRING_EXPLICIT_CONSTRUCTORS	// some CString constructors will be explicit
+#define VC_EXTRALEAN
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#define _ATL_ALL_WARNINGS
+
 
 #include "resource.h"
 #include <atlbase.h>

--- a/Src/ClassicIE/ClassicIEDLL/targetver.h
+++ b/Src/ClassicIE/ClassicIEDLL/targetver.h
@@ -7,18 +7,15 @@
 
 // Modify the following defines if you have to target a platform prior to the ones specified below.
 // Refer to MSDN for the latest info on corresponding values for different platforms.
-#ifndef WINVER                          // Specifies that the minimum required platform is Windows 7.
-#define WINVER 0x0602           // Change this to the appropriate value to target other versions of Windows.
+
+#ifndef _WIN32_WINNT                   // Specifies that the minimum required platform is Windows 7.
+#define _WIN32_WINNT _WIN32_WINNT_WIN7 // Change this to the appropriate value to target other versions of Windows.
 #endif
 
-#ifndef _WIN32_WINNT            // Specifies that the minimum required platform is Windows 7.
-#define _WIN32_WINNT 0x0602     // Change this to the appropriate value to target other versions of Windows.
+#ifndef _WIN32_IE                      // Specifies that the minimum required platform is Internet Explorer 11.0.
+#define _WIN32_IE _WIN32_IE_IE110      // Change this to the appropriate value to target other versions of IE.
 #endif
 
-#ifndef _WIN32_WINDOWS          // Specifies that the minimum required platform is Windows 98.
-#define _WIN32_WINDOWS 0x0410 // Change this to the appropriate value to target Windows Me or later.
-#endif
-
-#ifndef _WIN32_IE                       // Specifies that the minimum required platform is Internet Explorer 7.0.
-#define _WIN32_IE 0x0700        // Change this to the appropriate value to target other versions of IE.
+#ifndef NTDDI_VERSION                  // Specifies that the minimum required platform is NTDDI for Windows 8.
+#define NTDDI_VERSION NTDDI_WIN8       // Change this to the appropriate value to target other versions of NTDDI.
 #endif

--- a/Src/Lib/ResourceHelper.cpp
+++ b/Src/Lib/ResourceHelper.cpp
@@ -1,5 +1,5 @@
 // Classic Shell (c) 2009-2017, Ivo Beltchev
-// Open-Shell (c) 2017-2018, The Open-Shell Team
+// Open-Shell (c) 2017-2024, The Open-Shell Team
 // Confidential information of Ivo Beltchev. Not for disclosure or distribution without prior written consent from the author
 
 #include "stdafx.h"
@@ -648,7 +648,7 @@ DWORD GetVersionEx( HINSTANCE hInstance, DWORD *pBuild )
 }
 
 // Returns the Windows version - 0x600, 0x601, ...
-WORD GetWinVersion( void )
+WORD GetWinVersion()
 {
 	static WORD version;
 	if (!version)
@@ -660,21 +660,21 @@ WORD GetWinVersion( void )
 	return version;
 }
 
-static bool IsWin81Update1Helper( void )
+static bool IsWin81Update1Helper()
 {
 	DWORD build;
 	DWORD ver=GetVersionEx(GetModuleHandle(L"user32.dll"),&build);
-	return HIWORD(ver)==WIN_VER_WIN81 && build>17000;
+	return HIWORD(ver)==_WIN32_WINNT_WINBLUE && build>17000;
 }
 
 // Returns true if the version is Win81 Update1 or later
-bool IsWin81Update1( void )
+bool IsWin81Update1()
 {
 	static bool bIsUpdate1=IsWin81Update1Helper();
 	return bIsUpdate1;
 }
 
-static bool IsWin10RS1Helper( void )
+static bool IsWin10RS1Helper()
 {
 	DWORD build;
 	DWORD ver=GetVersionEx(GetModuleHandle(L"user32.dll"),&build);
@@ -682,7 +682,7 @@ static bool IsWin10RS1Helper( void )
 }
 
 // Returns true if the version is Windows10 RS1 or later
-bool IsWin10RS1( void )
+bool IsWin10RS1()
 {
 	static bool bIsRS1=IsWin10RS1Helper();
 	return bIsRS1;
@@ -720,14 +720,14 @@ static RTL_OSVERSIONINFOW GetOSVersion()
 	return ver;
 }
 
-static bool IsWin10RS4Helper( void )
+static bool IsWin10RS4Helper()
 {
 	auto version = GetOSVersion();
 	return version.dwMajorVersion > 8 && version.dwBuildNumber > 17131;
 }
 
 // Returns true if the version is Windows10 RS4 (Spring Creator Update) or later
-bool IsWin10RS4( void )
+bool IsWin10RS4()
 {
 	static bool bIsRS4=IsWin10RS4Helper();
 	return bIsRS4;
@@ -740,7 +740,7 @@ static bool IsWin11Helper()
 }
 
 // Returns true if the version is Windows11 or later
-bool IsWin11(void)
+bool IsWin11()
 {
 	static bool bIsWin11 = IsWin11Helper();
 	return bIsWin11;

--- a/Src/Lib/ResourceHelper.h
+++ b/Src/Lib/ResourceHelper.h
@@ -1,5 +1,5 @@
 // Classic Shell (c) 2009-2017, Ivo Beltchev
-// Open-Shell (c) 2017-2018, The Open-Shell Team
+// Open-Shell (c) 2017-2024, The Open-Shell Team
 // Confidential information of Ivo Beltchev. Not for disclosure or distribution without prior written consent from the author
 
 #pragma once
@@ -49,23 +49,17 @@ HICON CreateDisabledIcon( HICON hIcon, int iconSize );
 // Returns the version of a given module
 DWORD GetVersionEx( HINSTANCE hInstance, DWORD *pBuild=NULL );
 
-const int WIN_VER_VISTA=0x600;
-const int WIN_VER_WIN7 =0x601;
-const int WIN_VER_WIN8 =0x602;
-const int WIN_VER_WIN81=0x603;
-const int WIN_VER_WIN10=0xA00;
-
 // Returns the Windows version - 0x600, 0x601, ...
-WORD GetWinVersion( void );
+WORD GetWinVersion();
 
 // Returns true if the version is Win81 Update1
-bool IsWin81Update1( void );
+bool IsWin81Update1();
 
 // Returns true if the version is Windows10 RS1 or later
-bool IsWin10RS1( void );
+bool IsWin10RS1();
 
 // Returns true if the version is Windows10 RS4 (Spring Creator Update) or later
-bool IsWin10RS4( void );
+bool IsWin10RS4();
 
 // Returns true if the version is Windows11 or later
 bool IsWin11();

--- a/Src/Lib/StringUtils.h
+++ b/Src/Lib/StringUtils.h
@@ -41,6 +41,8 @@
 #include <stdarg.h>
 
 #if defined(_WIN32) || defined(_WIN64)
+#define VC_EXTRALEAN
+#define NOMINMAX
 #include <windows.h>
 #endif
 

--- a/Src/Lib/TrackResources.cpp
+++ b/Src/Lib/TrackResources.cpp
@@ -143,7 +143,7 @@ static const GdiTableCell *GetGdiTable( void )
 	if (GdiQueryTable)
 	{
 		// GdiQueryTable();
-		if (GetWinVersion()>=WIN_VER_WIN8)
+		if (GetWinVersion()>= _WIN32_WINNT_WIN8)
 			return *(GdiTableCell**)((char*)GdiQueryTable+0x6b1b0);
 		else
 			return *(GdiTableCell**)((char*)GdiQueryTable+0x29db0);

--- a/Src/Lib/stdafx.h
+++ b/Src/Lib/stdafx.h
@@ -8,6 +8,9 @@
 #include "targetver.h"
 
 #define STRICT_TYPED_ITEMIDS
+#define VC_EXTRALEAN
+#define NOMINMAX
+#define _ATL_ALL_WARNINGS
 // Windows Header Files:
 #include <windows.h>
 #include <commctrl.h>

--- a/Src/Lib/targetver.h
+++ b/Src/Lib/targetver.h
@@ -7,18 +7,15 @@
 
 // Modify the following defines if you have to target a platform prior to the ones specified below.
 // Refer to MSDN for the latest info on corresponding values for different platforms.
-#ifndef WINVER                          // Specifies that the minimum required platform is Windows 7.
-#define WINVER 0x0602           // Change this to the appropriate value to target other versions of Windows.
+
+#ifndef _WIN32_WINNT                   // Specifies that the minimum required platform is Windows 7.
+#define _WIN32_WINNT _WIN32_WINNT_WIN7 // Change this to the appropriate value to target other versions of Windows.
 #endif
 
-#ifndef _WIN32_WINNT            // Specifies that the minimum required platform is Windows 7.
-#define _WIN32_WINNT 0x0602     // Change this to the appropriate value to target other versions of Windows.
+#ifndef _WIN32_IE                      // Specifies that the minimum required platform is Internet Explorer 11.0.
+#define _WIN32_IE _WIN32_IE_IE110      // Change this to the appropriate value to target other versions of IE.
 #endif
 
-#ifndef _WIN32_WINDOWS          // Specifies that the minimum required platform is Windows 98.
-#define _WIN32_WINDOWS 0x0410 // Change this to the appropriate value to target Windows Me or later.
-#endif
-
-#ifndef _WIN32_IE                       // Specifies that the minimum required platform is Internet Explorer 7.0.
-#define _WIN32_IE 0x0700        // Change this to the appropriate value to target other versions of IE.
+#ifndef NTDDI_VERSION                  // Specifies that the minimum required platform is NTDDI for Windows 8.
+#define NTDDI_VERSION NTDDI_WIN8       // Change this to the appropriate value to target other versions of NTDDI.
 #endif

--- a/Src/Setup/Setup.cpp
+++ b/Src/Setup/Setup.cpp
@@ -2,7 +2,9 @@
 // Open-Shell (c) 2017-2018, The Open-Shell Team
 // Confidential information of Ivo Beltchev. Not for disclosure or distribution without prior written consent from the author
 
-#define _WIN32_WINNT 0x0600
+#define VC_EXTRALEAN
+#define NOMINMAX
+#define _ATL_ALL_WARNINGS
 #include <windows.h>
 #include <shlwapi.h>
 #include <stdio.h>

--- a/Src/Setup/SetupHelper/SetupHelper.cpp
+++ b/Src/Setup/SetupHelper/SetupHelper.cpp
@@ -1,9 +1,12 @@
 // Classic Shell (c) 2009-2017, Ivo Beltchev
-// Open-Shell (c) 2017-2018, The Open-Shell Team
+// Open-Shell (c) 2017-2024, The Open-Shell Team
 // Confidential information of Ivo Beltchev. Not for disclosure or distribution without prior written consent from the author
 
 #define STRICT_TYPED_ITEMIDS
 #define _ATL_CSTRING_EXPLICIT_CONSTRUCTORS	// some CString constructors will be explicit
+#define VC_EXTRALEAN
+#define NOMINMAX
+#define _ATL_ALL_WARNINGS
 #include <windows.h>
 #include <atlstr.h>
 #include "ResourceHelper.h"

--- a/Src/Setup/Utility/ManualUninstall.cpp
+++ b/Src/Setup/Utility/ManualUninstall.cpp
@@ -946,9 +946,9 @@ static void ManualUninstallInternal( void )
 
 	// remove TreatAs, app launcher keys
 	WORD winVer=HIWORD(GetVersionEx(GetModuleHandle(L"user32.dll")));
-	if (winVer>=WIN_VER_WIN8)
+	if (winVer>=_WIN32_WINNT_WIN8)
 	{
-		if (!RemoveRegistryKeys(winVer>=WIN_VER_WIN10))
+		if (!RemoveRegistryKeys(winVer>=_WIN32_WINNT_WIN10))
 		{
 			progress.DestroyWindow();
 			return;

--- a/Src/Setup/Utility/SaveLogFile.cpp
+++ b/Src/Setup/Utility/SaveLogFile.cpp
@@ -4,6 +4,9 @@
 
 #define STRICT_TYPED_ITEMIDS
 #define _ATL_CSTRING_EXPLICIT_CONSTRUCTORS	// some CString constructors will be explicit
+#define _ATL_ALL_WARNINGS
+#define VC_EXTRALEAN
+#define NOMINMAX
 #include <windows.h>
 #include <stdio.h>
 #include <atlstr.h>

--- a/Src/Setup/Utility/SaveLogFile.cpp
+++ b/Src/Setup/Utility/SaveLogFile.cpp
@@ -452,7 +452,7 @@ static void WriteLogFile( FILE *f )
 			pPath.Clear();
 		fwprintf(f,L"\tCommon Programs folder: '%s'\r\n",pPath?pPath:L"");
 	}
-	if (HIWORD(winVer)<WIN_VER_WIN8)
+	if (HIWORD(winVer)<_WIN32_WINNT_WIN8)
 	{
 		DWORD count;
 		if (ReadRegistryValue(HKEY_LOCAL_MACHINE,L"Software\\Microsoft\\Windows\\CurrentVersion\\WindowsUpdate\\Auto Update\\UAS",L"UpdateCount",count)==ERROR_SUCCESS)
@@ -487,7 +487,7 @@ static void WriteLogFile( FILE *f )
 		}
 	}
 
-	if (HIWORD(winVer)>=WIN_VER_WIN81)
+	if (HIWORD(winVer)>=_WIN32_WINNT_WINBLUE)
 	{
 		DWORD metro;
 		if (ReadRegistryValue(HKEY_CURRENT_USER,L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\StartPage",L"OpenAtLogon",metro)==ERROR_SUCCESS)
@@ -779,7 +779,7 @@ static void WriteLogFile( FILE *f )
 
 	if (bClassicMenu)
 	{
-		if (HIWORD(winVer)>=WIN_VER_WIN8)
+		if (HIWORD(winVer)>=_WIN32_WINNT_WIN8)
 		{
 			CString guid;
 			LONG res=ReadRegistryValue(HKEY_CLASSES_ROOT,L"CLSID\\{ECD4FC4D-521C-11D0-B792-00A0C90312E1}\\TreatAs",NULL,guid);

--- a/Src/Setup/Utility/Utility.cpp
+++ b/Src/Setup/Utility/Utility.cpp
@@ -1,9 +1,12 @@
 // Classic Shell (c) 2009-2017, Ivo Beltchev
-// Open-Shell (c) 2017-2018, The Open-Shell Team
+// Open-Shell (c) 2017-2024, The Open-Shell Team
 // Confidential information of Ivo Beltchev. Not for disclosure or distribution without prior written consent from the author
 
 #define STRICT_TYPED_ITEMIDS
 #define _ATL_CSTRING_EXPLICIT_CONSTRUCTORS	// some CString constructors will be explicit
+#define VC_EXTRALEAN
+#define NOMINMAX
+#define _ATL_ALL_WARNINGS
 #include <windows.h>
 #include <stdio.h>
 #include <vector>

--- a/Src/StartMenu/StartMenu.cpp
+++ b/Src/StartMenu/StartMenu.cpp
@@ -43,7 +43,7 @@ static bool HookStartMenu( THookMode mode, HWND &menu )
 
 	DllLogToFile(STARTUP_LOG,L"StartMenu: hooking Explorer");
 	HWND progWin=NULL;
-	bool bFindAppManager=(mode==HOOK_STARTUP && GetWinVersion()>=WIN_VER_WIN8 && GetWinVersion()<=WIN_VER_WIN81);
+	bool bFindAppManager=(mode==HOOK_STARTUP && GetWinVersion()>=_WIN32_WINNT_WIN8 && GetWinVersion()<=_WIN32_WINNT_WINBLUE);
 	for (int i=0;i<120;i++) // retry for 1 minute
 	{
 		if (bFindAppManager)
@@ -432,7 +432,7 @@ int WINAPI wWinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpstrC
 
 	DllLogToFile(STARTUP_LOG,L"StartMenu: start '%s'",lpstrCmdLine);
 
-	if (wcsstr(lpstrCmdLine,L"-startup") || (wcsstr(lpstrCmdLine,L"-autorun") && HIWORD(g_winVer)<WIN_VER_WIN8))
+	if (wcsstr(lpstrCmdLine,L"-startup") || (wcsstr(lpstrCmdLine,L"-autorun") && HIWORD(g_winVer)<_WIN32_WINNT_WIN8))
 	{
 		WaitDllInitThread();
 		if (!DllGetSettingBool(L"AutoStart"))

--- a/Src/StartMenu/StartMenuDLL/CustomMenu.cpp
+++ b/Src/StartMenu/StartMenuDLL/CustomMenu.cpp
@@ -466,7 +466,7 @@ const StdMenuItem *ParseCustomMenu( unsigned int &rootSettings )
 					}
 				}
 			}
-			if (GetWinVersion()<WIN_VER_WIN8 || GetSettingInt(L"ProgramsStyle")==PROGRAMS_INLINE || !GetSettingBool(L"AllProgramsMetro"))
+			if (GetWinVersion()<_WIN32_WINNT_WIN8 || GetSettingInt(L"ProgramsStyle")==PROGRAMS_INLINE || !GetSettingBool(L"AllProgramsMetro"))
 				len+=Strcpy(buf+len,_countof(buf)-len,L"ProgramsMenu.Items=\n");
 
 			menuText=buf;

--- a/Src/StartMenu/StartMenuDLL/DragDrop.cpp
+++ b/Src/StartMenu/StartMenuDLL/DragDrop.cpp
@@ -275,7 +275,7 @@ bool CMenuContainer::DragOut( int index, bool bApp )
 	// get IDataObject for the current item
 	CComPtr<IDataObject> pDataObj;
 	bool bProtectedLink=false;
-	if (bApp && GetWinVersion()<WIN_VER_WIN10)
+	if (bApp && GetWinVersion()<_WIN32_WINNT_WIN10)
 		pDataObj=CreateMetroDataObject(item.pItemInfo);
 	else
 	{

--- a/Src/StartMenu/StartMenuDLL/DragDrop.cpp
+++ b/Src/StartMenu/StartMenuDLL/DragDrop.cpp
@@ -722,9 +722,9 @@ HRESULT STDMETHODCALLTYPE CMenuContainer::Drop( IDataObject *pDataObj, DWORD grf
 
 	int folderIndex=0;
 	if (before>=0)
-		folderIndex=m_Items[min(before,(int)m_Items.size()-1)].priority>1?1:0;
+		folderIndex=m_Items[std::min(before,(int)m_Items.size()-1)].priority>1?1:0;
 
-	if (s_pDragSource==this && !s_bDragFromTree && s_bDragMovable && (*pdwEffect&DROPEFFECT_MOVE) && m_DragIndex!=m_ProgramTreeIndex && m_Items[m_DragIndex].priority==(m_Items[min(before,(int)m_Items.size()-1)].priority&2))
+	if (s_pDragSource==this && !s_bDragFromTree && s_bDragMovable && (*pdwEffect&DROPEFFECT_MOVE) && m_DragIndex!=m_ProgramTreeIndex && m_Items[m_DragIndex].priority==(m_Items[std::min(before,(int)m_Items.size()-1)].priority&2))
 	{
 		if (before==m_DragIndex || before==m_DragIndex+1)
 			return S_OK;

--- a/Src/StartMenu/StartMenuDLL/ItemManager.cpp
+++ b/Src/StartMenu/StartMenuDLL/ItemManager.cpp
@@ -123,11 +123,11 @@ static CComPtr<IApplicationResolver> g_pAppResolver;
 // Creates the app id resolver object
 static void CreateAppResolver( void )
 {
-	if (GetWinVersion()>=WIN_VER_WIN7)
+	if (GetWinVersion()>=_WIN32_WINNT_WIN7)
 	{
 		CComPtr<IUnknown> pUnknown;
 		pUnknown.CoCreateInstance(CLSID_ApplicationResolver);
-		if (GetWinVersion()==WIN_VER_WIN7)
+		if (GetWinVersion()==_WIN32_WINNT_WIN7)
 			g_pAppResolver=CComQIPtr<IApplicationResolver,&IID_IApplicationResolver7>(pUnknown);
 		else
 			g_pAppResolver=CComQIPtr<IApplicationResolver,&IID_IApplicationResolver8>(pUnknown);
@@ -851,7 +851,7 @@ static bool ComparePidls( PIDLIST_ABSOLUTE pidl1, PIDLIST_ABSOLUTE pidl2 )
 const CItemManager::ItemInfo *CItemManager::GetItemInfo( IShellItem *pItem, PIDLIST_ABSOLUTE pidl, int refreshFlags, TLocation location )
 {
 	Assert(!RWLock::ThreadHasReadLock(RWLOCK_ITEMS));
-	if ((refreshFlags&INFO_METRO) && GetWinVersion()<WIN_VER_WIN8)
+	if ((refreshFlags&INFO_METRO) && GetWinVersion()<_WIN32_WINNT_WIN8)
 		refreshFlags&=~INFO_METRO;
 	CComString pName;
 	if (refreshFlags&INFO_NO_PATH)
@@ -952,7 +952,7 @@ const CItemManager::ItemInfo *CItemManager::GetItemInfo( CString path, int refre
 {
 	Assert(!RWLock::ThreadHasReadLock(RWLOCK_ITEMS));
 	Assert(!path.IsEmpty());
-	if ((refreshFlags&INFO_METRO) && GetWinVersion()<WIN_VER_WIN8)
+	if ((refreshFlags&INFO_METRO) && GetWinVersion()<_WIN32_WINNT_WIN8)
 		refreshFlags&=~INFO_METRO;
 	CString PATH=path;
 	StringUpper(PATH);
@@ -1130,7 +1130,7 @@ const CItemManager::ItemInfo *CItemManager::GetCustomIcon( const wchar_t *path, 
 	{
 		if (IsWin11())
 			index=-IDI_APPSICON11;
-		else if (GetWinVersion()==WIN_VER_WIN10)
+		else if (GetWinVersion()==_WIN32_WINNT_WIN10)
 			index=-IDI_APPSICON10;
 	}
 	return GetCustomIcon(text,index,iconSizeType,false);
@@ -1634,7 +1634,7 @@ void CItemManager::UpdateNewPrograms( const POINT &balloonPos )
 				m_NewProgramRoots.push_back(GetItemInfo(pFolder,pidl,0));
 		}
 	}
-	if (GetWinVersion()>=WIN_VER_WIN8)
+	if (GetWinVersion()>=_WIN32_WINNT_WIN8)
 	{
 		wchar_t path[_MAX_PATH]=METRO_APP_ROOT;
 		DoEnvironmentSubst(path,_countof(path));
@@ -1831,7 +1831,7 @@ void CItemManager::RefreshItemInfo( ItemInfo *pInfo, int refreshFlags, IShellIte
 	CComPtr<IShellItem> pAppItem;
 	bool bStartScreen=
 #ifndef STARTSCREEN_WIN7
-		GetWinVersion()>=WIN_VER_WIN8 &&
+		GetWinVersion()>=_WIN32_WINNT_WIN8 &&
 #endif
 		(_wcsicmp(PathFindFileName(newInfo.PATH),STARTSCREEN_COMMAND)==0);
 	bool bValidateIcons=!bStartScreen; // hack - don't mark the icon as valid, so we have to load it next time
@@ -1938,12 +1938,12 @@ void CItemManager::RefreshItemInfo( ItemInfo *pInfo, int refreshFlags, IShellIte
 				}
 				if (pStore)
 				{
-					if (GetWinVersion()>=WIN_VER_WIN7)
+					if (GetWinVersion()>=_WIN32_WINNT_WIN7)
 					{
 						newInfo.appid=GetPropertyStoreString(pStore,PKEY_AppUserModel_ID);
 						newInfo.bExplicitAppId=!newInfo.appid.IsEmpty();
 					}
-					if (!newInfo.appid.IsEmpty() && (refreshFlags&INFO_METRO) && (GetWinVersion()<=WIN_VER_WIN8 || _wcsicmp(newInfo.appid,SEARCH_APP_ID)!=0))
+					if (!newInfo.appid.IsEmpty() && (refreshFlags&INFO_METRO) && (GetWinVersion()<=_WIN32_WINNT_WIN8 || _wcsicmp(newInfo.appid,SEARCH_APP_ID)!=0))
 					{
 						PROPVARIANT val;
 						PropVariantInit(&val);
@@ -2363,7 +2363,7 @@ void CItemManager::LoadShellIcon( IShellItem *pItem, int refreshFlags, const Ico
 	}
 	
 	Strcpy(metroLocation,_countof(metroLocation),location);
-	if (pMetroColor && GetWinVersion()>=WIN_VER_WIN10 && ParseMetroBitmapLocation2(metroLocation))
+	if (pMetroColor && GetWinVersion()>=_WIN32_WINNT_WIN10 && ParseMetroBitmapLocation2(metroLocation))
 	{
 		if (refreshFlags&INFO_SMALL_ICON)
 		{
@@ -2385,7 +2385,7 @@ void CItemManager::LoadShellIcon( IShellItem *pItem, int refreshFlags, const Ico
 		}
 	}
 
-	if (GetWinVersion()>=WIN_VER_WIN10)
+	if (GetWinVersion()>=_WIN32_WINNT_WIN10)
 		pMetroColor=NULL;
 
 	int smallIconSize=SMALL_ICON_SIZE;
@@ -2454,7 +2454,7 @@ void CItemManager::LoadShellIcon( IShellItem *pItem, int refreshFlags, const Ico
 
 static bool SetResContextTargetSize( IResourceContext *pResContext, int size )
 {
-	if (GetWinVersion()>=WIN_VER_WIN10)
+	if (GetWinVersion()>=_WIN32_WINNT_WIN10)
 	{
 		if (SUCCEEDED(pResContext->SetTargetSize(size)))
 			return true;
@@ -2792,7 +2792,7 @@ void CItemManager::LoadMetroItems( int refreshFlags )
 		}
 		if (m_LoadingStage!=LOAD_LOADING) break;
 	}
-	if (GetWinVersion()>=WIN_VER_WIN10)
+	if (GetWinVersion()>=_WIN32_WINNT_WIN10)
 	{
 		wchar_t APPID[256];
 		for (std::vector<MetroLink>::const_iterator it=links.begin();it!=links.end();++it)
@@ -2890,7 +2890,7 @@ void CItemManager::PreloadItemsThread( void )
 			}
 			else if (g_CacheFolders[i].folder==FOLDERID_MetroApps)
 			{
-				if (GetWinVersion()<WIN_VER_WIN8) continue;
+				if (GetWinVersion()<_WIN32_WINNT_WIN8) continue;
 				wchar_t path[_MAX_PATH]=METRO_APP_ROOT;
 				DoEnvironmentSubst(path,_countof(path));
 				pidl.Attach(ILCreateFromPath(path));

--- a/Src/StartMenu/StartMenuDLL/JumpLists.cpp
+++ b/Src/StartMenu/StartMenuDLL/JumpLists.cpp
@@ -104,7 +104,7 @@ CAutomaticList::CAutomaticList( const wchar_t *appid )
 			if (FAILED(m_pAutoList->Initialize(appid,NULL,NULL)))
 				m_pAutoList=NULL;
 		}
-		else if (GetWinVersion()>=WIN_VER_WIN10)
+		else if (GetWinVersion()>=_WIN32_WINNT_WIN10)
 		{
 			pAutoListUnk->QueryInterface(IID_IAutomaticDestinationList10b,(void**)&m_pAutoList10b);
 			if (m_pAutoList10b)
@@ -175,7 +175,7 @@ static CComPtr<IDestinationList> GetCustomList( const wchar_t *appid )
 	if (SUCCEEDED(pCustomListUnk.CoCreateInstance(CLSID_DestinationList)))
 	{
 		CComPtr<IDestinationList> pCustomList;
-		if (GetWinVersion()<WIN_VER_WIN10)
+		if (GetWinVersion()<_WIN32_WINNT_WIN10)
 			pCustomListUnk->QueryInterface(IID_IDestinationList,(void**)&pCustomList);
 		else
 		{
@@ -191,7 +191,7 @@ static CComPtr<IDestinationList> GetCustomList( const wchar_t *appid )
 // Returns true if the given app has a non-empty jumplist
 bool HasJumplist( const wchar_t *appid )
 {
-	Assert(GetWinVersion()>=WIN_VER_WIN7);
+	Assert(GetWinVersion()>=_WIN32_WINNT_WIN7);
 
 	CComPtr<IDestinationList> pCustomList=GetCustomList(appid);
 	if (pCustomList)
@@ -354,7 +354,7 @@ static void AddJumpCollection( CJumpGroup &group, IObjectCollection *pCollection
 // Returns the jumplist for the given shortcut
 bool GetJumplist( const wchar_t *appid, CJumpList &list, int maxCount, int maxHeight, int sepHeight, int itemHeight )
 {
-	Assert(GetWinVersion()>=WIN_VER_WIN7);
+	Assert(GetWinVersion()>=_WIN32_WINNT_WIN7);
 	list.Clear();
 
 	UINT categoryCount=0;
@@ -527,7 +527,7 @@ bool GetJumplist( const wchar_t *appid, CJumpList &list, int maxCount, int maxHe
 // Executes the given item using the correct application
 bool ExecuteJumpItem( const CItemManager::ItemInfo *pAppInfo, const CJumpItem &item, HWND hwnd )
 {
-	Assert(GetWinVersion()>=WIN_VER_WIN7);
+	Assert(GetWinVersion()>=_WIN32_WINNT_WIN7);
 	if (!item.pItem)
 		return false;
 

--- a/Src/StartMenu/StartMenuDLL/MenuCommands.cpp
+++ b/Src/StartMenu/StartMenuDLL/MenuCommands.cpp
@@ -1102,7 +1102,7 @@ static bool ExecuteSysCommand( TMenuID menuCommand )
 			return true;
 
 		case MENU_RUN: // show the Run box
-			if (GetWinVersion()>=WIN_VER_WIN10)
+			if (GetWinVersion()>=_WIN32_WINNT_WIN10)
 			{
 				ShellExecute(NULL,NULL,L"shell:::{2559a1f3-21d7-11d4-bdaf-00c04f60b9f0}",NULL,NULL,SW_SHOWNORMAL);
 			}
@@ -1136,7 +1136,7 @@ static bool ExecuteSysCommand( TMenuID menuCommand )
 			return true;
 
 		case MENU_SWITCHUSER: // switch_user
-			if (GetWinVersion()>=WIN_VER_WIN10)
+			if (GetWinVersion()>=_WIN32_WINNT_WIN10)
 			{
 				// on Windows 10 this value must be set to 1. For some reason non-admin code has permissions to do so
 				CRegKey regSwitch;
@@ -1202,7 +1202,7 @@ static bool ExecuteSysCommand( TMenuID menuCommand )
 			return true;
 
 		case MENU_PCSETTINGS:
-			if (GetWinVersion()>=WIN_VER_WIN8)
+			if (GetWinVersion()>=_WIN32_WINNT_WIN8)
 			{
 				ShellExecute(NULL,NULL,L"shell:appsfolder\\windows.immersivecontrolpanel_cw5n1h2txyewy!microsoft.windows.immersivecontrolpanel",NULL,NULL,SW_SHOWNORMAL);
 			}
@@ -1494,7 +1494,7 @@ void CMenuContainer::ActivateItem( int index, TActivateType type, const POINT *p
 		return;
 	}
 
-	bool bKeepOpen=(type==ACTIVATE_EXECUTE) && bShift && !bCtrl && (!item.bMetroLink || GetWinVersion()>=WIN_VER_WIN10);
+	bool bKeepOpen=(type==ACTIVATE_EXECUTE) && bShift && !bCtrl && (!item.bMetroLink || GetWinVersion()>=_WIN32_WINNT_WIN10);
 	bool bTrackRecent=false;
 	if (s_RecentPrograms!=RECENT_PROGRAMS_NONE)
 	{
@@ -1717,9 +1717,9 @@ void CMenuContainer::ActivateItem( int index, TActivateType type, const POINT *p
 					menuCommand=MENU_LOGOFF_CONFIRM;
 				break;
 			case MENU_RESTART:
-				if (GetWinVersion()>=WIN_VER_WIN8 && bShift)
+				if (GetWinVersion()>=_WIN32_WINNT_WIN8 && bShift)
 					menuCommand=MENU_RESTART_ADVANCED;
-				else if (s_bHasUpdates && GetWinVersion()>=WIN_VER_WIN8)
+				else if (s_bHasUpdates && GetWinVersion()>=_WIN32_WINNT_WIN8)
 					menuCommand=MENU_RESTART_UPDATE;
 				else
 					menuCommand=MENU_RESTART_NOUPDATE;
@@ -1727,7 +1727,7 @@ void CMenuContainer::ActivateItem( int index, TActivateType type, const POINT *p
 			case MENU_SHUTDOWN:
 				if (s_bHasUpdates)
 					menuCommand=MENU_SHUTDOWN_UPDATE;
-				else if (GetWinVersion()>=WIN_VER_WIN8 && !bShift && GetSettingBool(L"HybridShutdown"))
+				else if (GetWinVersion()>=_WIN32_WINNT_WIN8 && !bShift && GetSettingBool(L"HybridShutdown"))
 					menuCommand=MENU_SHUTDOWN_HYBRID;
 				else
 					menuCommand=MENU_SHUTDOWN_NOUPDATE;
@@ -1955,7 +1955,7 @@ void CMenuContainer::ActivateItem( int index, TActivateType type, const POINT *p
 				InsertMenu(menu,0,MF_BYPOSITION|MF_STRING,CMD_OPEN,FindTranslation(L"Menu.Open",L"&Open"));
 				SetMenuDefaultItem(menu,0,TRUE);
 				insertBefore++;
-				if (GetWinVersion()<WIN_VER_WIN10 && bUninstallPolicy && !bHasUninstall && !IsProtectedApp(_appId))
+				if (GetWinVersion()<_WIN32_WINNT_WIN10 && bUninstallPolicy && !bHasUninstall && !IsProtectedApp(_appId))
 				{
 					InsertMenu(menu,insertBefore,MF_BYPOSITION|MF_STRING,CMD_UNINSTALL,FindTranslation(L"Menu.Uninstall",L"&Uninstall"));
 					insertBefore++;
@@ -2000,7 +2000,7 @@ void CMenuContainer::ActivateItem( int index, TActivateType type, const POINT *p
 			InsertMenu(menu,0,MF_BYPOSITION|MF_STRING,CMD_OPEN,FindTranslation(L"Menu.Open",L"&Open"));
 			SetMenuDefaultItem(menu,0,TRUE);
 			insertBefore++;
-			if (GetWinVersion()<WIN_VER_WIN10 && bUninstallPolicy && !IsProtectedApp(_appId))
+			if (GetWinVersion()<_WIN32_WINNT_WIN10 && bUninstallPolicy && !IsProtectedApp(_appId))
 			{
 				InsertMenu(menu,insertBefore,MF_BYPOSITION|MF_STRING,CMD_UNINSTALL,FindTranslation(L"Menu.Uninstall",L"&Uninstall"));
 				insertBefore++;
@@ -2143,7 +2143,7 @@ void CMenuContainer::ActivateItem( int index, TActivateType type, const POINT *p
 				InsertMenu(menu,0,MF_BYPOSITION|MF_STRING,CMD_OPEN,FindTranslation(L"Menu.Open",L"&Open"));
 				SetMenuDefaultItem(menu,0,TRUE);
 				insertBefore++;
-				if (GetWinVersion()<WIN_VER_WIN10 && !bHasUninstall && bUninstallPolicy && !IsProtectedApp(_appId))
+				if (GetWinVersion()<_WIN32_WINNT_WIN10 && !bHasUninstall && bUninstallPolicy && !IsProtectedApp(_appId))
 				{
 					InsertMenu(menu,insertBefore,MF_BYPOSITION|MF_STRING,CMD_UNINSTALL,FindTranslation(L"Menu.Uninstall",L"&Uninstall"));
 					insertBefore++;
@@ -2382,7 +2382,7 @@ void CMenuContainer::ActivateItem( int index, TActivateType type, const POINT *p
 		if (item.id==MENU_PROGRAMS)
 		{
 			bool bNew;
-			if (s_bWin7Style && GetWinVersion()>=WIN_VER_WIN8 && GetSettingBool(L"AllProgramsMetro"))
+			if (s_bWin7Style && GetWinVersion()>=_WIN32_WINNT_WIN8 && GetSettingBool(L"AllProgramsMetro"))
 				bNew=g_ItemManager.HasNewPrograms(true) || g_ItemManager.HasNewApps(true);
 			else
 				bNew=g_ItemManager.HasNewPrograms(true);
@@ -2554,7 +2554,7 @@ void CMenuContainer::ActivateItem( int index, TActivateType type, const POINT *p
 			g_ItemManager.RemoveNewItems(false,true);
 		else if (item.id==MENU_PROGRAMS)
 		{
-			g_ItemManager.RemoveNewItems(true,s_bWin7Style && GetWinVersion()>=WIN_VER_WIN8 && GetSettingBool(L"AllProgramsMetro"));
+			g_ItemManager.RemoveNewItems(true,s_bWin7Style && GetWinVersion()>=_WIN32_WINNT_WIN8 && GetSettingBool(L"AllProgramsMetro"));
 			if (m_pProgramsTree)
 				m_pProgramsTree->ClearAllNew();
 		}
@@ -2932,7 +2932,7 @@ void CMenuContainer::ActivateItem( int index, TActivateType type, const POINT *p
 
 			if (bRenamed)
 			{
-				if (GetWinVersion()>=WIN_VER_WIN8)
+				if (GetWinVersion()>=_WIN32_WINNT_WIN8)
 				{
 					SetForegroundWindow(m_hWnd);
 					SetActiveWindow();
@@ -2969,7 +2969,7 @@ void CMenuContainer::ActivateItem( int index, TActivateType type, const POINT *p
 						}
 
 						// win7: if this is a pinned link with implicit app id, make it explicit - otherwise the app resolver will generate a new one
-						if (!m_bSubMenu && item.id==MENU_NO && GetWinVersion()<=WIN_VER_WIN7 && !_appId.IsEmpty() && _bIsLink && !_bExplicitAppId && SUCCEEDED(pFolder->GetDisplayNameOf(newPidl,SHGDN_FORPARSING,&str)))
+						if (!m_bSubMenu && item.id==MENU_NO && GetWinVersion()<=_WIN32_WINNT_WIN7 && !_appId.IsEmpty() && _bIsLink && !_bExplicitAppId && SUCCEEDED(pFolder->GetDisplayNameOf(newPidl,SHGDN_FORPARSING,&str)))
 						{
 							CComString pPath;
 							StrRetToStr(&str,newPidl,&pPath);

--- a/Src/StartMenu/StartMenuDLL/MenuContainer.cpp
+++ b/Src/StartMenu/StartMenuDLL/MenuContainer.cpp
@@ -5989,7 +5989,7 @@ LRESULT CMenuContainer::OnKeyDown( UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL
 						ytop-=m_ScrollOffset;
 						ybottom-=m_ScrollOffset;
 					}
-					int d=min(abs(ytop-y0),abs(ybottom-y0));
+					int d=std::min(abs(ytop-y0),abs(ybottom-y0));
 					if (dist>d)
 					{
 						index=i;
@@ -6056,7 +6056,7 @@ LRESULT CMenuContainer::OnKeyDown( UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL
 								ytop-=m_ScrollOffset;
 								ybottom-=m_ScrollOffset;
 							}
-							int d=min(abs(ytop-y0),abs(ybottom-y0));
+							int d= std::min(abs(ytop-y0),abs(ybottom-y0));
 							if (dist>d)
 							{
 								index=i;
@@ -7517,16 +7517,16 @@ POINT CMenuContainer::CalculateCorner( void )
 
 	POINT corner;
 	if (m_Options&CONTAINER_LEFT)
-		corner.x=max(s_MainMenuLimits.left,s_StartRect.left)+margin.left;
+		corner.x= std::max(s_MainMenuLimits.left,s_StartRect.left)+margin.left;
 	else
-		corner.x=min(s_MainMenuLimits.right,s_StartRect.right)+margin.right;
+		corner.x= std::min(s_MainMenuLimits.right,s_StartRect.right)+margin.right;
 
 	if (m_Options&CONTAINER_TOP)
 	{
 		if (s_bBehindTaskbar)
-			corner.y=max(s_MainMenuLimits.top,s_StartRect.top)+margin.top;
+			corner.y= std::max(s_MainMenuLimits.top,s_StartRect.top)+margin.top;
 		else
-			corner.y=max(s_MainMenuLimits.top,s_StartRect.top);
+			corner.y= std::max(s_MainMenuLimits.top,s_StartRect.top);
 	}
 	else
 		corner.y=s_MainMenuLimits.bottom+margin.bottom;

--- a/Src/StartMenu/StartMenuDLL/MenuContainer.cpp
+++ b/Src/StartMenu/StartMenuDLL/MenuContainer.cpp
@@ -823,7 +823,7 @@ void CMenuContainer::AddFirstFolder( IShellItem *pFolder, std::vector<MenuItem> 
 			bool bLibrary=_wcsicmp(PathFindExtension(pName),L".library-ms")==0;
 			bool bStartScreen=(
 #ifndef STARTSCREEN_WIN7
-				GetWinVersion()>=WIN_VER_WIN8 &&
+				GetWinVersion()>=_WIN32_WINNT_WIN8 &&
 #endif
 				wcscmp(pName,STARTSCREEN_COMMAND)==0);
 			const wchar_t *pStr=pName;
@@ -831,7 +831,7 @@ void CMenuContainer::AddFirstFolder( IShellItem *pFolder, std::vector<MenuItem> 
 				item.drive=(char)toupper(pStr[0]);
 			if (bStartScreen)
 			{
-				if (GetWinVersion()>=WIN_VER_WIN10)
+				if (GetWinVersion()>=_WIN32_WINNT_WIN10)
 					item.name=FindTranslation(L"Menu.StartMenu",L"Start Menu");
 				else
 					item.name=FindTranslation(L"Menu.StartScreen",L"Start Screen");
@@ -929,13 +929,13 @@ void CMenuContainer::AddSecondFolder( IShellItem *pFolder, std::vector<MenuItem>
 			bool bLibrary=_wcsicmp(PathFindExtension(pName),L".library-ms")==0;
 			bool bStartScreen=(
 #ifndef STARTSCREEN_WIN7
-				GetWinVersion()>=WIN_VER_WIN8 &&
+				GetWinVersion()>=_WIN32_WINNT_WIN8 &&
 #endif
 				wcscmp(pName,STARTSCREEN_COMMAND)==0);
 			MenuItem item(MENU_NO);
 			if (bStartScreen)
 			{
-				if (GetWinVersion()>=WIN_VER_WIN10)
+				if (GetWinVersion()>=_WIN32_WINNT_WIN10)
 					item.name=FindTranslation(L"Menu.StartMenu",L"Start Menu");
 				else
 					item.name=FindTranslation(L"Menu.StartScreen",L"Start Screen");
@@ -1395,7 +1395,7 @@ void CMenuContainer::AddStandardItems( void )
 					if (shutdown==SHUTDOWN_TYPE_RESTART)
 					{
 						item.name=FindTranslation(L"Menu.Restart",L"&Restart");
-						if (s_bHasUpdates && GetWinVersion()>=WIN_VER_WIN8)
+						if (s_bHasUpdates && GetWinVersion()>=_WIN32_WINNT_WIN8)
 							const_cast<StdMenuItem*>(item.pStdItem)->tip=FindTranslation(L"Menu.RestartUpdate",L"Update and restart");
 						else
 							const_cast<StdMenuItem*>(item.pStdItem)->tip=FindTranslation(L"Menu.RestartTip",L"");
@@ -1440,7 +1440,7 @@ void CMenuContainer::AddStandardItems( void )
 				}
 				else if (s_bHasUpdates && m_bSubMenu && item.id==MENU_SHUTDOWN)
 					item.name=FindTranslation(L"Menu.ShutdownUpdate",L"Update and shut down");
-				else if (s_bHasUpdates && m_bSubMenu && item.id==MENU_RESTART && GetWinVersion()>=WIN_VER_WIN8)
+				else if (s_bHasUpdates && m_bSubMenu && item.id==MENU_RESTART && GetWinVersion()>=_WIN32_WINNT_WIN8)
 					item.name=FindTranslation(L"Menu.RestartUpdate",L"Update and restart");
 				else
 					item.name=pStdItem->label;
@@ -1907,7 +1907,7 @@ void CMenuContainer::GetRecentPrograms( std::vector<MenuItem> &items, int maxCou
 			uaItems.push_back(uaItem);
 		}
 
-		if (GetWinVersion()>=WIN_VER_WIN10 && bShowMetro)
+		if (GetWinVersion()>=_WIN32_WINNT_WIN10 && bShowMetro)
 		{
 			// collect apps with positive rank from regKeyApp
 			for (int idx=0;;idx++)
@@ -2392,7 +2392,7 @@ void CMenuContainer::InitItems( void )
 		}
 	}
 
-	if ((m_Options&CONTAINER_APPS) && GetWinVersion()>=WIN_VER_WIN8)
+	if ((m_Options&CONTAINER_APPS) && GetWinVersion()>=_WIN32_WINNT_WIN8)
 	{
 		std::vector<MetroLink> links;
 		GetMetroLinks(links,true);
@@ -3287,7 +3287,7 @@ void CMenuContainer::InitWindowInternal( bool bDontShrink, const POINT &corner, 
 			{
 				if (item.id==MENU_PROGRAMS)
 				{
-					if (s_bWin7Style && GetWinVersion()>=WIN_VER_WIN8 && GetSettingBool(L"AllProgramsMetro"))
+					if (s_bWin7Style && GetWinVersion()>=_WIN32_WINNT_WIN8 && GetSettingBool(L"AllProgramsMetro"))
 						item.bNew=g_ItemManager.HasNewPrograms(false) || g_ItemManager.HasNewApps(false);
 					else
 						item.bNew=g_ItemManager.HasNewPrograms(false);
@@ -4428,7 +4428,7 @@ LRESULT CMenuContainer::OnCreate( UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL&
 		MARGINS margins={-1};
 		DwmExtendFrameIntoClientArea(m_hWnd,&margins);
 	}
-	else if ((opacity==MenuSkin::OPACITY_GLASS || opacity==MenuSkin::OPACITY_FULLGLASS) && GetWinVersion()>=WIN_VER_WIN10)
+	else if ((opacity==MenuSkin::OPACITY_GLASS || opacity==MenuSkin::OPACITY_FULLGLASS) && GetWinVersion()>=_WIN32_WINNT_WIN10)
 	{
 		tSetWindowCompositionAttribute SetWindowCompositionAttribute=(tSetWindowCompositionAttribute)GetProcAddress(GetModuleHandle(L"user32.dll"),"SetWindowCompositionAttribute");
 		if (SetWindowCompositionAttribute)
@@ -7374,7 +7374,7 @@ static void NewVersionCallback( VersionData &data )
 static bool CheckForUpdates( void )
 {
 	bool bHasUpdates=false;
-	if (GetWinVersion()<WIN_VER_WIN8)
+	if (GetWinVersion()<_WIN32_WINNT_WIN8)
 	{
 		CRegKey regKey;
 		if (regKey.Open(HKEY_LOCAL_MACHINE,L"Software\\Microsoft\\Windows\\CurrentVersion\\WindowsUpdate\\Auto Update\\UAS",KEY_READ)==ERROR_SUCCESS)
@@ -7401,7 +7401,7 @@ static bool CheckForUpdates( void )
 			}
 		}
 	}
-	if (!bHasUpdates && GetWinVersion()>=WIN_VER_WIN8)
+	if (!bHasUpdates && GetWinVersion()>=_WIN32_WINNT_WIN8)
 	{
 		typedef HRESULT (WINAPI *FGetAutoUpdateNotification)(DWORD,DWORD*,DWORD*,DWORD*);
 		HMODULE mod=LoadLibrary(L"wuaext.dll");
@@ -7645,7 +7645,7 @@ HWND CMenuContainer::ToggleStartMenu( int taskbarId, bool bKeyboard, bool bAllPr
 	GetTaskbarPosition(s_TaskBar,NULL,&initialMonitor,NULL);
 
 	int dpi=CItemManager::GetDPI(true);
-	if (!CItemManager::GetDPIOverride() && GetWinVersion()>=WIN_VER_WIN81)
+	if (!CItemManager::GetDPIOverride() && GetWinVersion()>=_WIN32_WINNT_WINBLUE)
 	{
 		HMODULE shModule=GetModuleHandle(L"Shcore.dll");
 		if (shModule)
@@ -7704,7 +7704,7 @@ HWND CMenuContainer::ToggleStartMenu( int taskbarId, bool bKeyboard, bool bAllPr
 	s_bNoCommonFolders=(SHRestricted(REST_NOCOMMONGROUPS)!=0);
 	s_bNoRun=(SHRestricted(REST_NORUN)!=0);
 	s_bNoClose=(SHRestricted(REST_NOCLOSE)!=0);
-	s_bHasTouch=GetWinVersion()>=WIN_VER_WIN8 && GetSettingBool(L"EnableTouch") && (GetSystemMetrics(SM_DIGITIZER)&NID_INTEGRATED_TOUCH)!=0;
+	s_bHasTouch=GetWinVersion()>=_WIN32_WINNT_WIN8 && GetSettingBool(L"EnableTouch") && (GetSystemMetrics(SM_DIGITIZER)&NID_INTEGRATED_TOUCH)!=0;
 	s_HasMoreResults=-1;
 	s_bDisableHover=false;
 	s_bDragClosed=false;
@@ -7725,7 +7725,7 @@ HWND CMenuContainer::ToggleStartMenu( int taskbarId, bool bKeyboard, bool bAllPr
 	}
 
 	// the taskbar on Windows 7 (and most likely later versions) is always on top even though it doesn't have the ABS_ALWAYSONTOP flag.
-	if (GetWinVersion()>=WIN_VER_WIN7)
+	if (GetWinVersion()>=_WIN32_WINNT_WIN7)
 	{
 		// also check the WS_EX_TOPMOST style - maybe some tool like DisableTaskbarOnTop is messing with it
 		if (::GetWindowLong(s_TaskBar,GWL_EXSTYLE)&WS_EX_TOPMOST)
@@ -7755,7 +7755,7 @@ HWND CMenuContainer::ToggleStartMenu( int taskbarId, bool bKeyboard, bool bAllPr
 			s_bActiveDirectory=0;
 	}
 
-	if (GetWinVersion()>=WIN_VER_WIN8 && !s_pFrameworkInputPane && !(GetSettingInt(L"CompatibilityFixes")&COMPATIBILITY_NO_TOUCH_KBD))
+	if (GetWinVersion()>=_WIN32_WINNT_WIN8 && !s_pFrameworkInputPane && !(GetSettingInt(L"CompatibilityFixes")&COMPATIBILITY_NO_TOUCH_KBD))
 	{
 		s_pFrameworkInputPane.CoCreateInstance(CLSID_FrameworkInputPane);
 	}
@@ -7875,7 +7875,7 @@ HWND CMenuContainer::ToggleStartMenu( int taskbarId, bool bKeyboard, bool bAllPr
 				g_StdOptions[i].options=(s_bHasUpdates && !s_bNoClose && (!bRemote || GetSettingBool(L"RemoteShutdown")))?MENU_ENABLED|MENU_EXPANDED:0;
 				break;
 			case MENU_RESTART_NOUPDATE:
-				g_StdOptions[i].options=(s_bHasUpdates && GetWinVersion()>=WIN_VER_WIN8 && !s_bNoClose && (!bRemote || GetSettingBool(L"RemoteShutdown")))?MENU_ENABLED|MENU_EXPANDED:0;
+				g_StdOptions[i].options=(s_bHasUpdates && GetWinVersion()>=_WIN32_WINNT_WIN8 && !s_bNoClose && (!bRemote || GetSettingBool(L"RemoteShutdown")))?MENU_ENABLED|MENU_EXPANDED:0;
 				break;
 			case MENU_SHUTDOWN_BOX:
 				g_StdOptions[i].options=0;
@@ -8044,10 +8044,10 @@ HWND CMenuContainer::ToggleStartMenu( int taskbarId, bool bKeyboard, bool bAllPr
 				}
 				break;
 			case MENU_APPS:
-				g_StdOptions[i].options=(s_bWin7Style || (GetWinVersion()>=WIN_VER_WIN8 && GetSettingBool(L"ShowAppsMenu")))?MENU_ENABLED|MENU_EXPANDED:0;
+				g_StdOptions[i].options=(s_bWin7Style || (GetWinVersion()>=_WIN32_WINNT_WIN8 && GetSettingBool(L"ShowAppsMenu")))?MENU_ENABLED|MENU_EXPANDED:0;
 				break;
 			case MENU_PCSETTINGS:
-				g_StdOptions[i].options=(GetWinVersion()>=WIN_VER_WIN8)?MENU_ENABLED|MENU_EXPANDED:0;
+				g_StdOptions[i].options=(GetWinVersion()>=_WIN32_WINNT_WIN8)?MENU_ENABLED|MENU_EXPANDED:0;
 				break;
 		}
 		LOG_MENU(LOG_OPEN,L"ItemOptions[%d]=%d",i,g_StdOptions[i].options);
@@ -8085,7 +8085,7 @@ HWND CMenuContainer::ToggleStartMenu( int taskbarId, bool bKeyboard, bool bAllPr
 		SHParseDisplayName(path,NULL,&path1,0,NULL);
 	}
 #ifndef STARTSCREEN_WIN7
-	if (GetWinVersion()>=WIN_VER_WIN8)
+	if (GetWinVersion()>=_WIN32_WINNT_WIN8)
 #endif
 	{
 		bool bPinned=GetSettingInt(L"PinnedPrograms")==PINNED_PROGRAMS_PINNED;

--- a/Src/StartMenu/StartMenuDLL/MenuPaint.cpp
+++ b/Src/StartMenu/StartMenuDLL/MenuPaint.cpp
@@ -91,7 +91,7 @@ HBITMAP CMenuContainer::LoadUserImage( int size, HBITMAP hMask )
 	CString str=GetSettingString(L"UserPicturePath");
 	if (str.IsEmpty())
 	{
-		if (GetWinVersion()==WIN_VER_WIN8)
+		if (GetWinVersion()==_WIN32_WINNT_WIN8)
 		{
 			CComPtr<IUserTileStore8> pStore;
 			pStore.CoCreateInstance(CLSID_UserTileStore);
@@ -102,7 +102,7 @@ HBITMAP CMenuContainer::LoadUserImage( int size, HBITMAP hMask )
 					Strcpy(path,_countof(path),pPath);
 			}
 		}
-		else if (GetWinVersion()==WIN_VER_WIN81)
+		else if (GetWinVersion()==_WIN32_WINNT_WINBLUE)
 		{
 			CComPtr<IUserTileStore81> pStore;
 			pStore.CoCreateInstance(CLSID_UserTileStore);
@@ -113,7 +113,7 @@ HBITMAP CMenuContainer::LoadUserImage( int size, HBITMAP hMask )
 					Strcpy(path,_countof(path),pPath);
 			}
 		}
-		else if (GetWinVersion()>=WIN_VER_WIN10)
+		else if (GetWinVersion()>=_WIN32_WINNT_WIN10)
 		{
 			CComPtr<IUserTileStore10> pStore;
 			pStore.CoCreateInstance(CLSID_UserTileStore);

--- a/Src/StartMenu/StartMenuDLL/MetroLinkManager.cpp
+++ b/Src/StartMenu/StartMenuDLL/MetroLinkManager.cpp
@@ -70,7 +70,7 @@ void GetMetroLinks( std::vector<MetroLink> &links, bool bLog, std::vector<CStrin
 			}
 			PropVariantClear(&val);
 		}
-		if (GetWinVersion()>=WIN_VER_WIN10)
+		if (GetWinVersion()>=_WIN32_WINNT_WIN10)
 		{
 			PIDLIST_ABSOLUTE pidl;
 			if (!bNonApp && SUCCEEDED(SHGetIDListFromObject(pChild,&pidl)))
@@ -177,7 +177,7 @@ void ExecutePCSettings( void )
 
 CComPtr<IContextMenu> GetMetroPinMenu( const wchar_t *appid )
 {
-	if (GetWinVersion()<WIN_VER_WIN10 && !IsWin81Update1()) return NULL;
+	if (GetWinVersion()<_WIN32_WINNT_WIN10 && !IsWin81Update1()) return NULL;
 	CComPtr<IShellFolder> pAppFolder;
 	{
 		CAbsolutePidl pidl;
@@ -228,7 +228,7 @@ bool IsProtectedApp( const wchar_t *appid )
 // Returns true if uninstalling is allowed by the policy
 bool GetUninstallPolicy( void )
 {
-	if (GetWinVersion()<WIN_VER_WIN8)
+	if (GetWinVersion()<_WIN32_WINNT_WIN8)
 		return false;
 	CRegKey regKey;
 	if (regKey.Open(HKEY_CURRENT_USER,L"Software\\Policies\\Microsoft\\Windows\\Explorer",KEY_READ)==ERROR_SUCCESS)
@@ -347,7 +347,7 @@ void UninstallMetroApp( HWND parent, const wchar_t *name, const wchar_t *appid )
 // Determines if Edge is the default browser
 bool IsEdgeDefaultBrowser( void )
 {
-	if (GetWinVersion()<WIN_VER_WIN10)
+	if (GetWinVersion()<_WIN32_WINNT_WIN10)
 		return false;
 	CRegKey userKey;
 	if (userKey.Open(HKEY_CURRENT_USER,L"Software\\Microsoft\\Windows\\Shell\\Associations\\UrlAssociations\\http\\UserChoice",KEY_READ)==ERROR_SUCCESS)

--- a/Src/StartMenu/StartMenuDLL/SearchManager.cpp
+++ b/Src/StartMenu/StartMenuDLL/SearchManager.cpp
@@ -680,13 +680,13 @@ void CSearchManager::SearchThread( void )
 					continue;
 
 				// Metro links
-				if (GetWinVersion()>=WIN_VER_WIN8 && searchRequest.bSearchMetroApps)
+				if (GetWinVersion()>=_WIN32_WINNT_WIN8 && searchRequest.bSearchMetroApps)
 				{
 					std::vector<MetroLink> links;
 					GetMetroLinks(links,true);
 					for (std::vector<MetroLink>::const_iterator it=links.begin();it!=links.end();++it)
 					{
-						if (GetWinVersion()<WIN_VER_WIN10)
+						if (GetWinVersion()<_WIN32_WINNT_WIN10)
 							AddSearchItem(it->pItem,L"",COLLECT_PROGRAMS|COLLECT_METRO|COLLECT_ONLY_METRO,CATEGORY_PROGRAM,searchRequest);
 						else
 						{
@@ -966,7 +966,7 @@ void CSearchManager::SearchThread( void )
 									LOG_MENU(LOG_SEARCH,L"Ignoring: failed to parse searchconnector-ms");
 									continue;
 								}
-								if (GetWinVersion()>=WIN_VER_WIN10)
+								if (GetWinVersion()>=_WIN32_WINNT_WIN10)
 								{
 									// ignore search connector using the WINRT scope - looks like it just duplicates the last search
 									bool bWinRT=false;

--- a/Src/StartMenu/StartMenuDLL/SettingsUI.cpp
+++ b/Src/StartMenu/StartMenuDLL/SettingsUI.cpp
@@ -2634,7 +2634,7 @@ HICON CCustomMenuDlg7::CItemList::LoadIcon( const MenuItem &item, bool bSmall ) 
 			TNetworkType networkType;
 			MenuParseDisplayName(buf,&pidl,NULL,&networkType);
 			// disable for now, to match the tree item icon loading
-			if (pidl && GetWinVersion()>=WIN_VER_WIN8 && _wcsicmp(PathFindExtension(buf),L".lnk")==0)
+			if (pidl && GetWinVersion()>=_WIN32_WINNT_WIN8 && _wcsicmp(PathFindExtension(buf),L".lnk")==0)
 			{
 				CComPtr<IShellItem> pItem;
 				if (SUCCEEDED(SHCreateItemFromIDList(pidl,IID_IShellItem,(void**)&pItem)))
@@ -3790,7 +3790,7 @@ LRESULT CMenuStyleDlg::OnInitDialog( UINT uMsg, WPARAM wParam, LPARAM lParam, BO
 
 	m_hIcon=NULL;
 	m_IconPath="?";
-	SetDlgItemText(IDC_CHECKENABLED,LoadStringEx(GetWinVersion()==WIN_VER_WIN8?IDS_ENABLE_BUTTON:IDS_ENABLE_BUTTON2));
+	SetDlgItemText(IDC_CHECKENABLED,LoadStringEx(GetWinVersion()==_WIN32_WINNT_WIN8?IDS_ENABLE_BUTTON:IDS_ENABLE_BUTTON2));
 	m_ButtonAero=GetDlgItem(IDC_STATICAERO);
 	m_ButtonClassic=GetDlgItem(IDC_STATICCLASSIC);
 	m_ButtonCustom=GetDlgItem(IDC_STATICCUSTOM);
@@ -4671,7 +4671,7 @@ static CString GetWindowsBrandingString()
 {
 	CString retval;
 
-	if (GetWinVersion() >= WIN_VER_WIN10)
+	if (GetWinVersion() >= _WIN32_WINNT_WIN10)
 	{
 		auto winbrand = LoadLibraryEx(L"winbrand.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
 		if (winbrand)
@@ -4843,7 +4843,7 @@ void UpdateSettings( void )
 	}
 	UpdateSetting(L"MenuUsername",CComVariant(title),false);
 
-	if (GetWinVersion()>=WIN_VER_WIN8)
+	if (GetWinVersion()>=_WIN32_WINNT_WIN8)
 	{
 		HideSettingGroup(L"WindowsMenu",true);
 		HideSettingGroup(L"AllProgramsSkin",true);
@@ -4856,7 +4856,7 @@ void UpdateSettings( void )
 
 		HideSetting(L"EnableTouch",!(GetSystemMetrics(SM_DIGITIZER)&NID_INTEGRATED_TOUCH));
 
-		bool bStartScreen=GetWinVersion()<WIN_VER_WIN10;
+		bool bStartScreen=GetWinVersion()<_WIN32_WINNT_WIN10;
 		CSetting *pSetting=FindSetting(L"MouseClick")+3;
 		pSetting->nameID=bStartScreen?IDS_OPEN_WSS:IDS_OPEN_WSM;
 		pSetting->tipID=bStartScreen?IDS_OPEN_WSS_TIP:IDS_OPEN_WSM_TIP;
@@ -4887,9 +4887,9 @@ void UpdateSettings( void )
 			UpdateSettingText(L"OpenMouseMonitor",IDS_MOUSE_MONITOR2,IDS_MOUSE_MONITOR_TIP2,false);
 		UpdateSettingText(L"ShiftRight",IDS_RIGHT_SHIFTX,IDS_RIGHT_SHIFTX_TIP,false);
 
-		if (GetWinVersion()>=WIN_VER_WIN81)
+		if (GetWinVersion()>=_WIN32_WINNT_WINBLUE)
 		{
-			if (GetWinVersion()>=WIN_VER_WIN10)
+			if (GetWinVersion()>=_WIN32_WINNT_WIN10)
 			{
 				UpdateGroupText(L"Metro",IDS_METRO_SETTINGS10);
 				UpdateSetting(L"SkipMetro",CComVariant(0),false); HideSetting(L"SkipMetro",true);
@@ -4942,7 +4942,7 @@ void UpdateSettings( void )
 #endif
 		UpdateSetting(L"HighlightNewApps",CComVariant(0),false); HideSetting(L"HighlightNewApps",true);
 	}
-	if (GetWinVersion()<WIN_VER_WIN10)
+	if (GetWinVersion()<_WIN32_WINNT_WIN10)
 	{
 		int dr, dg, db, da, dc;
 		GetSystemGlassColor(dr,dg,db,da,dc);
@@ -4961,14 +4961,14 @@ void UpdateSettings( void )
 		UpdateSetting(L"GlassBlending",CComVariant(100-da*100/255),false);
 		HideSetting(L"GlassOpacity",true);
 		UpdateSetting(L"EnableGlass",CComVariant(1),false); HideSetting(L"EnableGlass",true);
-		UpdateSetting(L"TaskbarOpacity",CComVariant(GetWinVersion()<=WIN_VER_WIN7?DEFAULT_TASK_OPACITY7:DEFAULT_TASK_OPACITY8),false);
-		if (GetWinVersion()>WIN_VER_WIN7)
+		UpdateSetting(L"TaskbarOpacity",CComVariant(GetWinVersion()<=_WIN32_WINNT_WIN7?DEFAULT_TASK_OPACITY7:DEFAULT_TASK_OPACITY8),false);
+		if (GetWinVersion()>_WIN32_WINNT_WIN7)
 		{
 			int color=GetSystemGlassColor8();
 			UpdateSetting(L"TaskbarColor",CComVariant(RgbToBgr(color)),false);
 		}
 
-		if (GetWinVersion()<=WIN_VER_WIN7)
+		if (GetWinVersion()<=_WIN32_WINNT_WIN7)
 		{
 			UpdateSetting(L"TaskbarLook",CComVariant(TASKBAR_GLASS),false);
 		}
@@ -5014,7 +5014,7 @@ void UpdateSettings( void )
 		// make games disabled by default if the folder doesn't exist (like on a server)
 		
 		const wchar_t *defaultMenu, *gameSettings0, *gameSettings1, *gameSettings2;
-		if (GetWinVersion()<WIN_VER_WIN81)
+		if (GetWinVersion()<_WIN32_WINNT_WINBLUE)
 		{
 			defaultMenu=g_DefaultStartMenu7;
 			gameSettings0=L"Item10.Command=games\n";
@@ -5050,7 +5050,7 @@ void UpdateSettings( void )
 		const wchar_t *skin12, *skin3;
 		const wchar_t *options1=L"", *options2=L"", *options3=L"";
 		bool bClassic;
-		if (GetWinVersion()<WIN_VER_WIN8)
+		if (GetWinVersion()<_WIN32_WINNT_WIN8)
 			bClassic=!IsAppThemed();
 		else
 		{
@@ -5076,7 +5076,7 @@ void UpdateSettings( void )
 				options3=L"USER_IMAGE=1\nSMALL_ICONS=0\nTHICK_BORDER=0\nSOLID_SELECTION=0\n";
 			}
 		}
-		else if (GetWinVersion()<WIN_VER_WIN8)
+		else if (GetWinVersion()<_WIN32_WINNT_WIN8)
 		{
 			BOOL comp=FALSE;
 			skin12=(SUCCEEDED(DwmIsCompositionEnabled(&comp)) && comp)?L"Windows Aero":L"Windows Basic";
@@ -5085,7 +5085,7 @@ void UpdateSettings( void )
 			options2=L"NO_ICONS=1\nUSER_IMAGE=1\nUSER_NAME=0\nCENTER_NAME=0\nSMALL_ICONS=0\nLARGE_FONT=0\nDISABLE_MASK=0\nWHITE_SUBMENUS=1\n";
 			options3=L"USER_IMAGE=1\nSMALL_ICONS=0\nLARGE_FONT=0\nDISABLE_MASK=0\nWHITE_SUBMENUS=1\n";
 		}
-		else if (GetWinVersion()<WIN_VER_WIN10)
+		else if (GetWinVersion()<_WIN32_WINNT_WIN10)
 		{
 			skin12=L"Windows 8";
 			skin3=L"Windows 8";
@@ -5145,7 +5145,7 @@ static MenuCustomSettings g_CustomSettings;
 
 void InitSettings( void )
 {
-	if (GetWinVersion()>WIN_VER_WIN8)
+	if (GetWinVersion()>_WIN32_WINNT_WIN8)
 	{
 		for (CSetting *pSetting=g_Settings;pSetting->name;pSetting++)
 			if (wcscmp(pSetting->name,L"SkipMetro")==0)
@@ -5210,7 +5210,7 @@ void ClosingSettings( HWND hWnd, int flags, int command )
 	{
 		if (flags&CSetting::FLAG_COLD)
 			MessageBox(hWnd,LoadStringEx(IDS_NEW_SETTINGS),LoadStringEx(IDS_APP_TITLE),MB_OK|MB_ICONWARNING);
-		if (GetWinVersion()>WIN_VER_WIN8)
+		if (GetWinVersion()>_WIN32_WINNT_WIN8)
 		{
 			CRegKey regSkip;
 			if (regSkip.Open(HKEY_CURRENT_USER,L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\StartPage",KEY_WRITE)==ERROR_SUCCESS)

--- a/Src/StartMenu/StartMenuDLL/SkinManager.cpp
+++ b/Src/StartMenu/StartMenuDLL/SkinManager.cpp
@@ -604,7 +604,7 @@ static bool GetSkinColorizationParameters( DWMCOLORIZATIONPARAMS *params )
 	tGetColorizationParameters GetColorizationParameters=(tGetColorizationParameters)GetProcAddress(hMod,MAKEINTRESOURCEA(127));
 	if (!GetColorizationParameters || FAILED(GetColorizationParameters(params)))
 		return false;
-	if (GetWinVersion()>=WIN_VER_WIN8)
+	if (GetWinVersion()>=_WIN32_WINNT_WIN8)
 		params->ColorizationOpaqueBlend=0; // Win8 has no transparency
 	return true;
 }
@@ -703,7 +703,7 @@ COLORREF GetMetroTaskbarColor( bool &bTransparent )
 
 COLORREF GetSystemAccentColor( void )
 {
-	if (GetImmersiveUserColorSetPreference!=NULL && GetWinVersion()>=WIN_VER_WIN10)
+	if (GetImmersiveUserColorSetPreference!=NULL && GetWinVersion()>=_WIN32_WINNT_WIN10)
 	{
 		int type=GetImmersiveColorTypeFromName(L"ImmersiveSystemAccent");
 		if (type>=0)
@@ -717,7 +717,7 @@ COLORREF GetSystemAccentColor( void )
 
 static void GetMenuGlassColor( int &dr, int &dg, int &db, int &da )
 {
-	if (GetWinVersion()>=WIN_VER_WIN10)
+	if (GetWinVersion()>=_WIN32_WINNT_WIN10)
 	{
 		bool bDef=true;
 		if (GetSettingBool(L"GlassOverride"))
@@ -1524,7 +1524,7 @@ bool MenuSkin::ComputeOptionStates( const std::map<CString,CString> &options, st
 		values.push_back(L"144_DPI");	// 150% scaling
 	else if (Dpi>=120)
 		values.push_back(L"120_DPI");	// 125% scaling
-	if (ForceTouch || (GetWinVersion()>=WIN_VER_WIN8 && GetSettingBool(L"EnableTouch") && (GetSystemMetrics(SM_DIGITIZER)&NID_INTEGRATED_TOUCH)!=0))
+	if (ForceTouch || (GetWinVersion()>=_WIN32_WINNT_WIN8 && GetSettingBool(L"EnableTouch") && (GetSystemMetrics(SM_DIGITIZER)&NID_INTEGRATED_TOUCH)!=0))
 		values.push_back(L"TOUCH_ENABLED");
 	if (GetSettingInt(L"SearchBox")!=SEARCHBOX_HIDDEN)
 		values.push_back(L"SEARCHBOX");
@@ -2877,7 +2877,7 @@ bool MenuSkin::LoadSkin( HMODULE hMod, const wchar_t *variation, const wchar_t *
 	Main_FakeGlass=false;
 	Submenu_FakeGlass=false;
 	WORD winVer=GetWinVersion();
-	if ((winVer>=WIN_VER_WIN8 && winVer<WIN_VER_WIN10 && !GetSettingBool(L"AeroGlass")) || (winVer>=WIN_VER_WIN10 && !GetSettingBool(L"EnableGlass")))
+	if ((winVer>=_WIN32_WINNT_WIN8 && winVer<_WIN32_WINNT_WIN10 && !GetSettingBool(L"AeroGlass")) || (winVer>=_WIN32_WINNT_WIN10 && !GetSettingBool(L"EnableGlass")))
 	{
 		// replace GLASS with ALPHA and enable the fake glass (alpha with less opacity)
 		if (Main_opacity==OPACITY_GLASS)
@@ -3044,7 +3044,7 @@ bool MenuSkin::LoadSkin( HMODULE hMod, const wchar_t *variation, const wchar_t *
 	}
 
 #ifndef SIMULATE_METRO_COLORS
-	if (!*s_SkinError && BHasMetroColors && GetWinVersion()==WIN_VER_WIN7)
+	if (!*s_SkinError && BHasMetroColors && GetWinVersion()==_WIN32_WINNT_WIN7)
 	{
 		Strcpy(s_SkinError,_countof(s_SkinError),LoadStringEx(IDS_SKIN_ERR_METRO_COLOR));
 		return false;
@@ -3071,7 +3071,7 @@ bool MenuSkin::LoadMenuSkin( const wchar_t *fname, const wchar_t *variation, con
 	BOOL bComp;
 	if (!bTheme || FAILED(DwmIsCompositionEnabled(&bComp)))
 		bComp=FALSE;
-	BOOL bEnableTouch=(GetWinVersion()>=WIN_VER_WIN8 && GetSettingBool(L"EnableTouch") && (GetSystemMetrics(SM_DIGITIZER)&NID_INTEGRATED_TOUCH)!=0);
+	BOOL bEnableTouch=(GetWinVersion()>=_WIN32_WINNT_WIN8 && GetSettingBool(L"EnableTouch") && (GetSystemMetrics(SM_DIGITIZER)&NID_INTEGRATED_TOUCH)!=0);
 	bool bAeroGlass=GetSettingBool(L"AeroGlass");
 	bool bEnableGlass=GetSettingBool(L"EnableGlass");
 	bool bSearchBox=GetSettingInt(L"SearchBox")!=SEARCHBOX_HIDDEN;

--- a/Src/StartMenu/StartMenuDLL/StartButton.cpp
+++ b/Src/StartMenu/StartMenuDLL/StartButton.cpp
@@ -381,7 +381,7 @@ LRESULT CStartButton::OnThemeChanged( UINT uMsg, WPARAM wParam, LPARAM lParam, B
 	if (m_Theme) CloseThemeData(m_Theme);
 	m_Theme=NULL;
 	HIGHCONTRAST contrast={sizeof(contrast)};
-	if (GetWinVersion()>=WIN_VER_WIN8 && SystemParametersInfo(SPI_GETHIGHCONTRAST,sizeof(contrast),&contrast,0) && (contrast.dwFlags&HCF_HIGHCONTRASTON))
+	if (GetWinVersion()>=_WIN32_WINNT_WIN8 && SystemParametersInfo(SPI_GETHIGHCONTRAST,sizeof(contrast),&contrast,0) && (contrast.dwFlags&HCF_HIGHCONTRASTON))
 	{
 		// only use themes on Win8 with high contrast
 		m_Theme=OpenThemeData(m_hWnd,L"button");
@@ -429,7 +429,7 @@ TStartButtonType GetStartButtonType( void )
 	if (bDef)
 	{
 		bool bClassic;
-		if (GetWinVersion()<WIN_VER_WIN8)
+		if (GetWinVersion()<_WIN32_WINNT_WIN8)
 			bClassic=!IsAppThemed();
 		else
 		{

--- a/Src/StartMenu/StartMenuDLL/StartMenuDLL.cpp
+++ b/Src/StartMenu/StartMenuDLL/StartMenuDLL.cpp
@@ -274,7 +274,7 @@ struct StartScreenThumbInfo
 
 static bool CreateImmersiveShell( CComPtr<IUnknown> &ptr )
 {
-	if (GetWinVersion()<WIN_VER_WIN8)
+	if (GetWinVersion()<_WIN32_WINNT_WIN8)
 		return false;
 	ptr.CoCreateInstance(CLSID_ImmersiveShell);
 	return ptr.p!=NULL;
@@ -455,7 +455,7 @@ STARTMENUAPI HWND FindTaskBar( DWORD process )
 	if (g_TaskBar)
 	{
 		// find start button
-		if (GetWinVersion()==WIN_VER_WIN7)
+		if (GetWinVersion()==_WIN32_WINNT_WIN7)
 			EnumThreadWindows(GetWindowThreadProcessId(g_TaskBar,NULL),FindStartButtonEnum,NULL);
 		if (GetWindowThreadProcessId(g_TaskBar,NULL)==GetCurrentThreadId())
 		{
@@ -795,7 +795,7 @@ public:
 	// IAppVisibilityEvents
 	virtual HRESULT STDMETHODCALLTYPE AppVisibilityOnMonitorChanged( HMONITOR hMonitor, MONITOR_APP_VISIBILITY previousMode, MONITOR_APP_VISIBILITY currentMode )
 	{
-		if (GetWinVersion()<WIN_VER_WIN10)
+		if (GetWinVersion()<_WIN32_WINNT_WIN10)
 		{
 			ResetHotCorners();
 			if (IsWin81Update1() && GetSettingBool(L"CustomTaskbar"))
@@ -807,7 +807,7 @@ public:
 	virtual HRESULT STDMETHODCALLTYPE LauncherVisibilityChange( BOOL currentVisibleState )
 	{
 		CComPtr<IUnknown> pImmersiveShell;
-		if (GetWinVersion()>=WIN_VER_WIN10 && CreateImmersiveShell(pImmersiveShell))
+		if (GetWinVersion()>=_WIN32_WINNT_WIN10 && CreateImmersiveShell(pImmersiveShell))
 		{
 			int taskbarId=-1;
 			if (currentVisibleState)
@@ -957,14 +957,14 @@ static LRESULT CALLBACK HookAppManager( int code, WPARAM wParam, LPARAM lParam )
 									if (pMonitorService)
 									{
 										HMONITOR monitor=MonitorFromPoint(pt,MONITOR_DEFAULTTONEAREST);
-										if (GetWinVersion()==WIN_VER_WIN8)
+										if (GetWinVersion()==_WIN32_WINNT_WIN8)
 										{
 											CComPtr<IUnknown> pMonitor;
 											pMonitorService->GetFromHandle(monitor,&pMonitor);
 											if (pMonitor)
 												pMonitorService->SetImmersiveMonitor(pMonitor);
 										}
-										else if (GetWinVersion()>WIN_VER_WIN8)
+										else if (GetWinVersion()>_WIN32_WINNT_WIN8)
 										{
 											// doesn't seem to be doing anything on 8.1, but do it just in case
 											CComPtr<IUnknown> pMonitor;
@@ -1001,7 +1001,7 @@ static LRESULT CALLBACK HookAppManager( int code, WPARAM wParam, LPARAM lParam )
 							}
 							if (msg->wParam==MSG_SHIFTWIN)
 							{
-								if (GetWinVersion()==WIN_VER_WIN8)
+								if (GetWinVersion()==_WIN32_WINNT_WIN8)
 								{
 									HMONITOR monitor=(HMONITOR)msg->lParam;
 									if (monitor)
@@ -1280,7 +1280,7 @@ static void UpdateStartButtonPosition(const TaskbarInfo* taskBar, const WINDOWPO
 	if (!IsStartButtonSmallIcons(taskBar->taskbarId))
 	{
 		bool bClassic;
-		if (GetWinVersion() < WIN_VER_WIN8)
+		if (GetWinVersion() < _WIN32_WINNT_WIN8)
 			bClassic = !IsAppThemed();
 		else
 		{
@@ -1393,7 +1393,7 @@ static LRESULT CALLBACK SubclassWin81StartButton( HWND hWnd, UINT uMsg, WPARAM w
 		}
 	}
 #endif
-	if (uMsg==WM_PAINT && GetWinVersion()>=WIN_VER_WIN10)
+	if (uMsg==WM_PAINT && GetWinVersion()>=_WIN32_WINNT_WIN10)
 	{
 		g_CurrentTaskbarButton=hWnd;
 		LRESULT res=DefSubclassProc(hWnd,uMsg,wParam,lParam);
@@ -1520,11 +1520,13 @@ static BOOL CALLBACK FindWindowsMenuProc( HWND hwnd, LPARAM lParam )
 	if (_wcsicmp(name,L"DV2ControlHost")==0)
 	{
 		HWND w1=hwnd;
-		if (GetWinVersion()==WIN_VER_VISTA)
+#if _WIN32_WINNT > _WIN32_WINNT_VISTA
+		if (GetWinVersion()==_WIN32_WINNT_VISTA)
 		{
 			w1=FindWindowEx(w1,NULL,L"Desktop Open Pane Host",NULL);
 			if (!w1) return TRUE;
 		}
+#endif
 		w1=FindWindowEx(w1,NULL,L"Desktop More Programs Pane",NULL);
 		if (!w1) return TRUE;
 
@@ -1539,7 +1541,7 @@ static BOOL CALLBACK FindWindowsMenuProc( HWND hwnd, LPARAM lParam )
 static void FindWindowsMenu( void )
 {
 	if (g_TopWin7Menu) return;
-	if (GetWinVersion()<WIN_VER_WIN8)
+	if (GetWinVersion()<_WIN32_WINNT_WIN8)
 	{
 		Assert(GetCurrentThreadId()==GetWindowThreadProcessId(g_TaskBar,NULL));
 		EnumThreadWindows(GetCurrentThreadId(),FindWindowsMenuProc,0);
@@ -1606,7 +1608,7 @@ static void ComputeTaskbarColors( int *data )
 {
 	bool bDefLook;
 	int look=GetSettingInt(L"TaskbarLook",bDefLook);
-	if (GetWinVersion()<WIN_VER_WIN10 || look==TASKBAR_AEROGLASS || (look==TASKBAR_TRANSPARENT && g_TaskbarTexture))
+	if (GetWinVersion()<_WIN32_WINNT_WIN10 || look==TASKBAR_AEROGLASS || (look==TASKBAR_TRANSPARENT && g_TaskbarTexture))
 	{
 		memset(data,0,16);
 	}
@@ -1643,7 +1645,7 @@ static void ShowWinX( void )
 		return;
 	}
 
-	if (GetWinVersion()>=WIN_VER_WIN10)
+	if (GetWinVersion()>=_WIN32_WINNT_WIN10)
 	{
 		CComPtr<IUnknown> pImmersiveShell;
 		if (CreateImmersiveShell(pImmersiveShell))
@@ -1720,9 +1722,9 @@ static LRESULT CALLBACK SubclassTrayButtonProc( HWND hWnd, UINT uMsg, WPARAM wPa
 
 static LRESULT CALLBACK SubclassTaskBarProc( HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, UINT_PTR uIdSubclass, DWORD_PTR dwRefData )
 {
-	if (uMsg==WM_MOUSEACTIVATE && (HIWORD(lParam)==WM_MBUTTONDOWN || GetWinVersion()>=WIN_VER_WIN10))
+	if (uMsg==WM_MOUSEACTIVATE && (HIWORD(lParam)==WM_MBUTTONDOWN || GetWinVersion()>=_WIN32_WINNT_WIN10))
 	{
-		if (GetWinVersion()>=WIN_VER_WIN10 && CMenuContainer::IsMenuOpened() && CMenuContainer::HasInputHandler() && GetFocus())
+		if (GetWinVersion()>=_WIN32_WINNT_WIN10 && CMenuContainer::IsMenuOpened() && CMenuContainer::HasInputHandler() && GetFocus())
 		{
 			// Win10: if the taskbar is clicked while the menu is opened, check if the touch keyboard button was clicked and ignore the activation
 			// Otherwise the click on the touch keyboard button will deactivate the menu (possibly because both run on the same thread)
@@ -1798,7 +1800,7 @@ static LRESULT CALLBACK SubclassTaskBarProc( HWND hWnd, UINT uMsg, WPARAM wParam
 		if (PointAroundStartButton((int)dwRefData,CPoint(lParam)))
 		{
 			int control=GetSettingInt(L"MouseClick");
-			if (control==OPEN_BOTH && GetWinVersion()>=WIN_VER_WIN10)
+			if (control==OPEN_BOTH && GetWinVersion()>=_WIN32_WINNT_WIN10)
 				control=GetWin10TabletMode()?OPEN_WINDOWS:OPEN_CLASSIC;
 			if (control==OPEN_CLASSIC)
 				ToggleStartMenu(taskBar->taskbarId,false);
@@ -1829,7 +1831,7 @@ static LRESULT CALLBACK SubclassTaskBarProc( HWND hWnd, UINT uMsg, WPARAM wParam
 		{
 			UpdateStartButtonPosition(taskBar,(WINDOWPOS*)lParam);
 		}
-		if (taskBar->oldButton && GetWinVersion()<WIN_VER_WIN10)
+		if (taskBar->oldButton && GetWinVersion()<_WIN32_WINNT_WIN10)
 		{
 			UINT uEdge=GetTaskbarPosition(hWnd,NULL,NULL,NULL);
 			int x=(uEdge==ABE_BOTTOM?-1:0);
@@ -1847,7 +1849,7 @@ static LRESULT CALLBACK SubclassTaskBarProc( HWND hWnd, UINT uMsg, WPARAM wParam
 		taskBar->bThemeChanging=false;
 		return res;
 	}
-	if ((uMsg==WM_DWMCOLORIZATIONCOLORCHANGED || uMsg==WM_SETTINGCHANGE || uMsg==0x5CB || uMsg==0x5BB) && taskBar && taskBar->bCustomLook && SetWindowCompositionAttribute && GetWinVersion()>=WIN_VER_WIN10)
+	if ((uMsg==WM_DWMCOLORIZATIONCOLORCHANGED || uMsg==WM_SETTINGCHANGE || uMsg==0x5CB || uMsg==0x5BB) && taskBar && taskBar->bCustomLook && SetWindowCompositionAttribute && GetWinVersion()>=_WIN32_WINNT_WIN10)
 	{
 		LRESULT res=DefSubclassProc(hWnd,uMsg,wParam,lParam);
 		int data[4];
@@ -1856,7 +1858,7 @@ static LRESULT CALLBACK SubclassTaskBarProc( HWND hWnd, UINT uMsg, WPARAM wParam
 		SetWindowCompositionAttribute(hWnd,&attrData);
 		return res;
 	}
-	if ((uMsg==WM_DWMCOLORIZATIONCOLORCHANGED || uMsg==WM_SETTINGCHANGE) && taskBar && taskBar->bCustomLook && SetWindowCompositionAttribute && GetWinVersion()<WIN_VER_WIN10)
+	if ((uMsg==WM_DWMCOLORIZATIONCOLORCHANGED || uMsg==WM_SETTINGCHANGE) && taskBar && taskBar->bCustomLook && SetWindowCompositionAttribute && GetWinVersion()<_WIN32_WINNT_WIN10)
 	{
 		LRESULT res=DefSubclassProc(hWnd,uMsg,wParam,lParam);
 		UpdateTaskBars(TASKBAR_UPDATE_TEXTURE);
@@ -1872,25 +1874,25 @@ static LRESULT CALLBACK SubclassTaskBarProc( HWND hWnd, UINT uMsg, WPARAM wParam
 			int margin;
 			enum { FLAG_BLUR=1, FLAG_MARGIN=2, FLAG_ATTRIBUTE=4};
 			int flags=0;
-			if (winVer==WIN_VER_WIN7)
+			if (winVer==_WIN32_WINNT_WIN7)
 			{
 				blurBehind=look==TASKBAR_GLASS;
 				margin=look==TASKBAR_OPAQUE?0:-1;
 				flags=FLAG_BLUR|FLAG_MARGIN;
 			}
-			else if (winVer==WIN_VER_WIN8)
+			else if (winVer==_WIN32_WINNT_WIN8)
 			{
 				blurBehind=look==TASKBAR_OPAQUE;
 				margin=look==TASKBAR_OPAQUE?0:-1;
 				flags=FLAG_BLUR|FLAG_MARGIN|((look==TASKBAR_TRANSPARENT && g_TaskbarTexture)?FLAG_ATTRIBUTE:0);
 			}
-			else if (winVer==WIN_VER_WIN81)
+			else if (winVer==_WIN32_WINNT_WINBLUE)
 			{
 				blurBehind=look==TASKBAR_OPAQUE;
 				margin=look==TASKBAR_OPAQUE?0:-1;
 				flags=FLAG_BLUR|FLAG_MARGIN|((look==TASKBAR_OPAQUE || g_TaskbarTexture)?FLAG_ATTRIBUTE:0);
 			}
-			else if (winVer>=WIN_VER_WIN10)
+			else if (winVer>=_WIN32_WINNT_WIN10)
 			{
 				blurBehind=TRUE;
 				margin=look==TASKBAR_OPAQUE?0:-1;
@@ -2016,14 +2018,14 @@ static LRESULT CALLBACK SubclassTaskBarProc( HWND hWnd, UINT uMsg, WPARAM wParam
 	{
 		ResetHotCorners();
 	}
-	if (uMsg==WM_NCLBUTTONDOWN && taskBar && GetWinVersion()==WIN_VER_WIN7 && taskBar->bReplaceButton)
+	if (uMsg==WM_NCLBUTTONDOWN && taskBar && GetWinVersion()==_WIN32_WINNT_WIN7 && taskBar->bReplaceButton)
 	{
 		g_bSuppressMessage243=true;
 		LRESULT res=DefSubclassProc(hWnd,uMsg,wParam,lParam);
 		g_bSuppressMessage243=false;
 		return res;
 	}
-	if (uMsg==WM_PARENTNOTIFY && taskBar && LOWORD(wParam)==WM_CREATE && GetWinVersion()>=WIN_VER_WIN10)
+	if (uMsg==WM_PARENTNOTIFY && taskBar && LOWORD(wParam)==WM_CREATE && GetWinVersion()>=_WIN32_WINNT_WIN10)
 	{
 		wchar_t name[100];
 		HWND child=(HWND)lParam;
@@ -2225,7 +2227,7 @@ static void HandleTaskbarParts( TaskbarInfo &taskBar, bool bPrimary )
 				SetWindowSubclass(clock,SubclassTaskbarPartProc,'CLSH',taskBar.taskbarId);
 				taskBar.taskbarParts.push_back(clock);
 			}
-			if (GetWinVersion()<=WIN_VER_WIN81)
+			if (GetWinVersion()<=_WIN32_WINNT_WINBLUE)
 			{
 				taskBar.desktop=FindWindowEx(tray,NULL,L"TrayShowDesktopButtonWClass",NULL);
 				if (taskBar.desktop)
@@ -2233,7 +2235,7 @@ static void HandleTaskbarParts( TaskbarInfo &taskBar, bool bPrimary )
 			}
 		}
 	}
-	else if (GetWinVersion()>=WIN_VER_WIN10)
+	else if (GetWinVersion()>=_WIN32_WINNT_WIN10)
 	{
 		HWND clock=FindWindowEx(taskBar.taskBar,NULL,L"ClockButton",NULL);
 		if (clock && !taskBar.HasPart(clock))
@@ -2259,12 +2261,12 @@ static void HandleSecondaryTaskbar( HWND hwnd )
 		if (taskBar.taskList)
 			SetWindowSubclass(taskBar.taskList,SubclassTaskListProc,'CLSH',taskbarId);
 	}
-	if (GetWinVersion()>WIN_VER_WIN8)
+	if (GetWinVersion()>_WIN32_WINNT_WIN8)
 	{
 		taskBar.oldButton=FindWindowEx(taskBar.taskBar,NULL,L"Start",NULL);
 		if (taskBar.oldButton)
 		{
-			if (GetWinVersion()>=WIN_VER_WIN10)
+			if (GetWinVersion()>=_WIN32_WINNT_WIN10)
 			{
 				taskBar.pOriginalTarget=(IDropTarget*)GetProp(taskBar.oldButton,L"OleDropTargetInterface");
 				if (taskBar.pOriginalTarget)
@@ -2274,12 +2276,12 @@ static void HandleSecondaryTaskbar( HWND hwnd )
 			CStartMenuTarget *pNewTarget=new CStartMenuTarget(taskBar.taskbarId);
 			RegisterDragDrop(taskBar.oldButton,pNewTarget);
 			pNewTarget->Release();
-			if (GetWinVersion()<WIN_VER_WIN10 && GetTaskbarPosition(taskBar.taskBar,NULL,NULL,NULL)==ABE_BOTTOM)
+			if (GetWinVersion()<_WIN32_WINNT_WIN10 && GetTaskbarPosition(taskBar.taskBar,NULL,NULL,NULL)==ABE_BOTTOM)
 				SetWindowPos(taskBar.oldButton,NULL,-1,0,0,0,SWP_NOSIZE|SWP_NOZORDER);
 			SetWindowSubclass(taskBar.oldButton,SubclassWin81StartButton,'CLSH',taskBar.taskbarId);
 		}
 	}
-	if (GetWinVersion()>=WIN_VER_WIN10)
+	if (GetWinVersion()>=_WIN32_WINNT_WIN10)
 	{
 		for (HWND button=FindWindowEx(taskBar.taskBar,NULL,L"TrayButton",NULL);button;button=FindWindowEx(taskBar.taskBar,button,L"TrayButton",NULL))
 		{
@@ -2365,9 +2367,9 @@ void UpdateTaskBars( TUpdateTaskbar update )
 					}
 				}
 			}
-			else if (GetWinVersion()<WIN_VER_WIN10 && (!bDefColor || !bDefOpacity))
+			else if (GetWinVersion()<_WIN32_WINNT_WIN10 && (!bDefColor || !bDefOpacity))
 			{
-				if (bDefColor && GetWinVersion()>WIN_VER_WIN7)
+				if (bDefColor && GetWinVersion()>_WIN32_WINNT_WIN7)
 				{
 					color=GetSystemGlassColor8();
 					color=((color&0xFF)<<16)|(color&0xFF00)|((color>>16)&0xFF);
@@ -2509,7 +2511,7 @@ void UpdateTaskBars( TUpdateTaskbar update )
 				{
 					ShowWindow(g_WinStartButton,SW_HIDE);
 					SetWindowSubclass(g_WinStartButton,SubclassWin7StartButton,'CLSH',0);
-					if (GetWinVersion()==WIN_VER_WIN7)
+					if (GetWinVersion()==_WIN32_WINNT_WIN7)
 					{
 						// Windows 7 draws the start button on the taskbar as well
 						// so we zero out the bitmap resources
@@ -2594,11 +2596,11 @@ void UpdateTaskBars( TUpdateTaskbar update )
 			// set custom look
 			taskBar.bCustomLook=bCustomLook;
 
-			if (!bCustomLook && GetWinVersion()<WIN_VER_WIN10)
+			if (!bCustomLook && GetWinVersion()<_WIN32_WINNT_WIN10)
 			{
-				DWM_BLURBEHIND blur={DWM_BB_ENABLE,GetWinVersion()<WIN_VER_WIN8};
+				DWM_BLURBEHIND blur={DWM_BB_ENABLE,GetWinVersion()<_WIN32_WINNT_WIN8};
 				DwmEnableBlurBehindWindow(taskBar.taskBar,&blur);
-				if (GetWinVersion()==WIN_VER_WIN7)
+				if (GetWinVersion()==_WIN32_WINNT_WIN7)
 				{
 					MARGINS margins={0};
 					DwmExtendFrameIntoClientArea(taskBar.taskBar,&margins);
@@ -2895,7 +2897,7 @@ void NTAPI DisableShellHotkeysFunc(ULONG_PTR Parameter)
 
 static void OpenCortana( void )
 {
-	if (GetWinVersion()>=WIN_VER_WIN10)
+	if (GetWinVersion()>=_WIN32_WINNT_WIN10)
 		ShellExecute(NULL,NULL,L"shell:::{2559a1f8-21d7-11d4-bdaf-00c04f60b9f0}",NULL,NULL,SW_SHOWNORMAL);
 }
 
@@ -2943,7 +2945,7 @@ static void InitStartMenuDLL( void )
 		if (!module)
 			module=GetModuleHandle(NULL);
 
-		if (GetWinVersion()>=WIN_VER_WIN10)
+		if (GetWinVersion()>=_WIN32_WINNT_WIN10)
 		{
 			HMODULE shlwapi=GetModuleHandle(L"shlwapi.dll");
 			if (shlwapi)
@@ -2967,17 +2969,17 @@ static void InitStartMenuDLL( void )
 			DestroyWindow(dlg);
 		}
 
-		if (GetWinVersion()<=WIN_VER_WIN81)
+		if (GetWinVersion()<=_WIN32_WINNT_WINBLUE)
 			g_DrawThemeBackgroundHook=SetIatHook(module,"uxtheme.dll","DrawThemeBackground",DrawThemeBackground2);
 		g_DrawThemeTextHook=SetIatHook(module,"uxtheme.dll","DrawThemeText",DrawThemeText2);
 		g_DrawThemeTextExHook=SetIatHook(module,"uxtheme.dll","DrawThemeTextEx",DrawThemeTextEx2);
 		g_DrawThemeTextCtlHook=SetIatHook(GetModuleHandle(L"comctl32.dll"),"uxtheme.dll","DrawThemeText",DrawThemeText2);
-		if (GetWinVersion()>=WIN_VER_WIN10)
+		if (GetWinVersion()>=_WIN32_WINNT_WIN10)
 			g_SetWindowCompositionAttributeHook=SetIatHook(module,"user32.dll","SetWindowCompositionAttribute",SetWindowCompositionAttribute2);
 	}
 
 	g_TaskbarThreadId=GetCurrentThreadId();
-	g_bTrimHooks=GetWinVersion()==WIN_VER_WIN7 && (GetSettingInt(L"CompatibilityFixes")&COMPATIBILITY_TRIM_HOOKS);
+	g_bTrimHooks=GetWinVersion()==_WIN32_WINNT_WIN7 && (GetSettingInt(L"CompatibilityFixes")&COMPATIBILITY_TRIM_HOOKS);
 	InitManagers(false);
 	int level=GetSettingInt(L"CrashDump");
 	if (level>=1 && level<=3)
@@ -3025,7 +3027,7 @@ static void InitStartMenuDLL( void )
 	HWND hwnd=FindWindow(L"OpenShellMenu.CStartHookWindow",L"StartHookWindow");
 	LoadLibrary(L"StartMenuDLL.dll"); // keep the DLL from unloading
 	if (hwnd) PostMessage(hwnd,WM_CLEAR,0,0); // tell the exe to unhook this hook
-	if (GetWinVersion()>=WIN_VER_WIN8)
+	if (GetWinVersion()>=_WIN32_WINNT_WIN8)
 	{
 		SetWindowCompositionAttribute=(tSetWindowCompositionAttribute)GetProcAddress(GetModuleHandle(L"user32.dll"),"SetWindowCompositionAttribute");
 	}
@@ -3052,12 +3054,12 @@ static void InitStartMenuDLL( void )
 		if (taskBar.taskList)
 			SetWindowSubclass(taskBar.taskList,SubclassTaskListProc,'CLSH',taskbarId);
 	}
-	if (GetWinVersion()>WIN_VER_WIN8)
+	if (GetWinVersion()>_WIN32_WINNT_WIN8)
 	{
 		taskBar.oldButton=FindWindowEx(taskBar.taskBar,NULL,L"Start",NULL);
 		if (taskBar.oldButton)
 		{
-			if (GetWinVersion()>=WIN_VER_WIN10)
+			if (GetWinVersion()>=_WIN32_WINNT_WIN10)
 			{
 				taskBar.pOriginalTarget=(IDropTarget*)GetProp(taskBar.oldButton,L"OleDropTargetInterface");
 				if (taskBar.pOriginalTarget)
@@ -3067,12 +3069,12 @@ static void InitStartMenuDLL( void )
 			CStartMenuTarget *pNewTarget=new CStartMenuTarget(taskBar.taskbarId);
 			RegisterDragDrop(taskBar.oldButton,pNewTarget);
 			pNewTarget->Release();
-			if (GetWinVersion()<WIN_VER_WIN10 && GetTaskbarPosition(taskBar.taskBar,NULL,NULL,NULL)==ABE_BOTTOM)
+			if (GetWinVersion()<_WIN32_WINNT_WIN10 && GetTaskbarPosition(taskBar.taskBar,NULL,NULL,NULL)==ABE_BOTTOM)
 				SetWindowPos(taskBar.oldButton,NULL,-1,0,0,0,SWP_NOSIZE|SWP_NOZORDER);
 			SetWindowSubclass(taskBar.oldButton,SubclassWin81StartButton,'CLSH',taskBar.taskbarId);
 		}
 	}
-	if (GetWinVersion()>=WIN_VER_WIN10)
+	if (GetWinVersion()>=_WIN32_WINNT_WIN10)
 	{
 		for (HWND button=FindWindowEx(g_TaskBar,NULL,L"TrayButton",NULL);button;button=FindWindowEx(g_TaskBar,button,L"TrayButton",NULL))
 		{
@@ -3110,7 +3112,7 @@ if (!g_bTrimHooks)
 	}
 #endif
 
-	if (GetWinVersion()>=WIN_VER_WIN8)
+	if (GetWinVersion()>=_WIN32_WINNT_WIN8)
 	{
 		g_pAppVisibility.CoCreateInstance(CLSID_MetroMode);
 		if (g_pAppVisibility)
@@ -3119,7 +3121,7 @@ if (!g_bTrimHooks)
 			g_pAppVisibility->Advise(monitor,&g_AppVisibilityMonitorCookie);
 			monitor->Release();
 		}
-		if (GetWinVersion()<WIN_VER_WIN10)
+		if (GetWinVersion()<_WIN32_WINNT_WIN10)
 		{
 			HWND hwndAppManager=FindWindow(L"ApplicationManager_DesktopShellWindow",NULL);
 			if (hwndAppManager)
@@ -3127,7 +3129,7 @@ if (!g_bTrimHooks)
 				g_AppManagerThread=GetWindowThreadProcessId(hwndAppManager,NULL);
 				g_AppManagerHook=SetWindowsHookEx(WH_GETMESSAGE,HookAppManager,g_Instance,g_AppManagerThread);
 			}
-			if (GetWinVersion()==WIN_VER_WIN8 && GetSettingBool(L"SkipMetro"))
+			if (GetWinVersion()==_WIN32_WINNT_WIN8 && GetSettingBool(L"SkipMetro"))
 			{
 				g_SkipMetroCount=abs(GetSettingInt(L"SkipMetroCount"));
 				SetTimer(g_TaskBar,'CLSM',500,NULL);
@@ -3258,7 +3260,7 @@ static void CleanStartMenuDLL( void )
 		if (it->second.oldButton)
 		{
 			RemoveWindowSubclass(it->second.oldButton,SubclassWin81StartButton,'CLSH');
-			if (GetWinVersion()<WIN_VER_WIN10 && GetTaskbarPosition(it->second.taskBar,NULL,NULL,NULL)==ABE_BOTTOM)
+			if (GetWinVersion()<_WIN32_WINNT_WIN10 && GetTaskbarPosition(it->second.taskBar,NULL,NULL,NULL)==ABE_BOTTOM)
 				SetWindowPos(it->second.oldButton,NULL,0,0,0,0,SWP_NOSIZE|SWP_NOZORDER);
 			RevokeDragDrop(it->second.oldButton);
 			if (it->second.pOriginalTarget)
@@ -3323,7 +3325,7 @@ static bool WindowsMenuOpened( void )
 {
 	FindWindowsMenu();
 	CComPtr<IUnknown> pImmersiveShell;
-	if (GetWinVersion()>=WIN_VER_WIN10 && CreateImmersiveShell(pImmersiveShell))
+	if (GetWinVersion()>=_WIN32_WINNT_WIN10 && CreateImmersiveShell(pImmersiveShell))
 	{
 		{
 			CComPtr<IImmersiveLauncher81> pLauncher;
@@ -3340,7 +3342,7 @@ static bool WindowsMenuOpened( void )
 				return bIsVisible!=0;
 		}
 	}
-	if (GetWinVersion()>=WIN_VER_WIN8)
+	if (GetWinVersion()>=_WIN32_WINNT_WIN8)
 	{
 		return GetMetroMode(NULL)!=METRO_NONE;
 	}
@@ -3356,7 +3358,7 @@ static void OpenStartScreen( HMONITOR monitor )
 	if (CreateImmersiveShell(pImmersiveShell))
 	{
 		CComPtr<IUnknown> pMonitor;
-		if (GetWinVersion()==WIN_VER_WIN8)
+		if (GetWinVersion()==_WIN32_WINNT_WIN8)
 		{
 			if (monitor)
 			{
@@ -3390,7 +3392,7 @@ static void OpenStartScreen( HMONITOR monitor )
 			{
 				if (pMonitor)
 					pLauncher->ConnectToMonitor(pMonitor);
-				HRESULT hr=pLauncher->ShowStartView(GetWinVersion()>=WIN_VER_WIN10?11:5,0);
+				HRESULT hr=pLauncher->ShowStartView(GetWinVersion()>=_WIN32_WINNT_WIN10?11:5,0);
 				return;
 			}
 		}
@@ -3401,7 +3403,7 @@ static void OpenStartScreen( HMONITOR monitor )
 			{
 				if (pMonitor)
 					pLauncher->ConnectToMonitor(pMonitor);
-				HRESULT hr=pLauncher->ShowStartView(GetWinVersion()>=WIN_VER_WIN10?11:5,0);
+				HRESULT hr=pLauncher->ShowStartView(GetWinVersion()>=_WIN32_WINNT_WIN10?11:5,0);
 				return;
 			}
 		}
@@ -3418,12 +3420,12 @@ static LRESULT CALLBACK HookProgManThread( int code, WPARAM wParam, LPARAM lPara
 		MSG *msg=(MSG*)lParam;
 		if (msg->message==WM_SYSCOMMAND && (msg->wParam&0xFFF0)==SC_TASKLIST)
 		{
-			if (GetWinVersion()<WIN_VER_WIN8 && !CMenuContainer::CanShowMenu())
+			if (GetWinVersion()<_WIN32_WINNT_WIN8 && !CMenuContainer::CanShowMenu())
 				msg->message=WM_NULL;
 			// Win button pressed
 			if (msg->lParam=='WSMK' || msg->lParam=='WSMM' || msg->lParam=='WSMH')
 			{
-				if ((g_AppManagerThread || GetWinVersion()>=WIN_VER_WIN10) && (msg->lParam=='WSMM' || msg->lParam=='WSMH' || (g_TaskbarInfos.size()>1 && GetSettingBool(L"OpenMouseMonitor"))))
+				if ((g_AppManagerThread || GetWinVersion()>=_WIN32_WINNT_WIN10) && (msg->lParam=='WSMM' || msg->lParam=='WSMH' || (g_TaskbarInfos.size()>1 && GetSettingBool(L"OpenMouseMonitor"))))
 				{
 					if (!WindowsMenuOpened())
 					{
@@ -3444,7 +3446,7 @@ static LRESULT CALLBACK HookProgManThread( int code, WPARAM wParam, LPARAM lPara
 				int control=GetSettingInt(L"WinKey");
 				if (control==OPEN_BOTH)
 				{
-					if (GetWinVersion()>=WIN_VER_WIN10)
+					if (GetWinVersion()>=_WIN32_WINNT_WIN10)
 						control=GetWin10TabletMode()?OPEN_WINDOWS:OPEN_CLASSIC;
 					else
 						control=GetMetroMode(MonitorFromPoint(CPoint(GetMessagePos()),MONITOR_DEFAULTTONEAREST))?OPEN_WINDOWS:OPEN_CLASSIC;
@@ -3472,7 +3474,7 @@ static LRESULT CALLBACK HookProgManThread( int code, WPARAM wParam, LPARAM lPara
 						SetForegroundWindow(taskBar->startButton?taskBar->startButton:taskBar->taskBar);
 						msg->message=WM_NULL;
 					}
-					else if (GetWinVersion()>=WIN_VER_WIN8 && g_TaskbarInfos.size()>1 && GetSettingBool(L"OpenMouseMonitor") && !WindowsMenuOpened())
+					else if (GetWinVersion()>=_WIN32_WINNT_WIN8 && g_TaskbarInfos.size()>1 && GetSettingBool(L"OpenMouseMonitor") && !WindowsMenuOpened())
 					{
 						HMONITOR monitor=MonitorFromPoint(CPoint(GetMessagePos()),MONITOR_DEFAULTTONULL);
 						OpenStartScreen(monitor);
@@ -3501,7 +3503,7 @@ static LRESULT CALLBACK HookProgManThread( int code, WPARAM wParam, LPARAM lPara
 				}
 			}
 		}
-		if ((msg->message==WM_MOUSEMOVE || msg->message==WM_LBUTTONDOWN) && GetWinVersion()>=WIN_VER_WIN8 && HIWORD(msg->lParam)<10 && GetSettingInt(L"DisableHotCorner")==2)
+		if ((msg->message==WM_MOUSEMOVE || msg->message==WM_LBUTTONDOWN) && GetWinVersion()>=_WIN32_WINNT_WIN8 && HIWORD(msg->lParam)<10 && GetSettingInt(L"DisableHotCorner")==2)
 		{
 			if (msg->hwnd!=g_TopDesktopBar || !g_TopDesktopBar || !IsWindow(g_TopDesktopBar))
 			{
@@ -3565,7 +3567,7 @@ static LRESULT CALLBACK HookDesktopThread( int code, WPARAM wParam, LPARAM lPara
 		}
 if (!g_bTrimHooks)
 {
-		if (((msg->message>=WM_MOUSEFIRST && msg->message<=WM_MOUSELAST) || msg->message==WM_MOUSEHOVER || msg->message==WM_MOUSELEAVE) && GetWinVersion()<=WIN_VER_WIN7 && CMenuContainer::ProcessMouseMessage(msg->hwnd,msg->message,msg->wParam,msg->lParam))
+		if (((msg->message>=WM_MOUSEFIRST && msg->message<=WM_MOUSELAST) || msg->message==WM_MOUSEHOVER || msg->message==WM_MOUSELEAVE) && GetWinVersion()<=_WIN32_WINNT_WIN7 && CMenuContainer::ProcessMouseMessage(msg->hwnd,msg->message,msg->wParam,msg->lParam))
 		{
 			msg->message=WM_NULL;
 			return 0;
@@ -3599,7 +3601,7 @@ if (!g_bTrimHooks)
 					int control=GetSettingInt(L"ShiftWin");
 					if (control==OPEN_BOTH)
 					{
-						if (GetWinVersion()>=WIN_VER_WIN10)
+						if (GetWinVersion()>=_WIN32_WINNT_WIN10)
 							control=GetWin10TabletMode()?OPEN_WINDOWS:OPEN_CLASSIC;
 						else
 							control=GetMetroMode(MonitorFromPoint(CPoint(GetMessagePos()),MONITOR_DEFAULTTONEAREST))?OPEN_WINDOWS:OPEN_CLASSIC;
@@ -3627,9 +3629,9 @@ if (!g_bTrimHooks)
 					if (taskBar)
 					{
 						int control=GetSettingInt((msg->wParam==MSG_DRAG)?L"MouseClick":L"ShiftClick");
-						if (control==OPEN_BOTH && GetWinVersion()>=WIN_VER_WIN10)
+						if (control==OPEN_BOTH && GetWinVersion()>=_WIN32_WINNT_WIN10)
 							control=GetWin10TabletMode()?OPEN_WINDOWS:OPEN_CLASSIC;
-						if (control==OPEN_CLASSIC || (control==OPEN_WINDOWS && GetWinVersion()>=WIN_VER_WIN8))
+						if (control==OPEN_CLASSIC || (control==OPEN_WINDOWS && GetWinVersion()>=_WIN32_WINNT_WIN8))
 							ToggleStartMenu(taskBar->taskbarId,true);
 						else if (control==OPEN_WINDOWS)
 							PostMessage(g_ProgWin,WM_SYSCOMMAND,SC_TASKLIST,'WSMM');
@@ -3721,7 +3723,7 @@ if (!g_bTrimHooks)
 				int control=GetSettingInt(L"WinKey");
 				if (control==OPEN_BOTH)
 				{
-					if (GetWinVersion()>=WIN_VER_WIN10)
+					if (GetWinVersion()>=_WIN32_WINNT_WIN10)
 						control=GetWin10TabletMode()?OPEN_WINDOWS:OPEN_CLASSIC;
 					else
 						control=GetMetroMode(MonitorFromWindow(g_TaskBar,MONITOR_DEFAULTTONEAREST))?OPEN_WINDOWS:OPEN_CLASSIC;
@@ -3767,7 +3769,7 @@ if (!g_bTrimHooks)
 			}
 			if (taskBar)
 			{
-				if (msg->message==WM_LBUTTONDOWN && GetWinVersion()==WIN_VER_WIN7 && msg->hwnd==taskBar->startButton)
+				if (msg->message==WM_LBUTTONDOWN && GetWinVersion()==_WIN32_WINNT_WIN7 && msg->hwnd==taskBar->startButton)
 				{
 					// on Win7 ignore the click if the mouse is not over the start button (clicks on the context menu are sent to the start button)
 					CPoint pt(GetMessagePos());
@@ -3797,7 +3799,7 @@ if (!g_bTrimHooks)
 				}
 
 				int control=GetSettingInt(name);
-				if (control==OPEN_BOTH && GetWinVersion()>=WIN_VER_WIN10)
+				if (control==OPEN_BOTH && GetWinVersion()>=_WIN32_WINNT_WIN10)
 					control=GetWin10TabletMode()?OPEN_WINDOWS:OPEN_CLASSIC;
 				if (control==OPEN_CLASSIC)
 				{
@@ -3981,7 +3983,7 @@ if (!g_bTrimHooks)
 		{
 			TaskbarInfo *taskBar=FindTaskBarInfoButton(msg->hwnd);
 			DWORD winVer=GetWinVersion();
-			if (!taskBar && winVer>=WIN_VER_WIN8)
+			if (!taskBar && winVer>=_WIN32_WINNT_WIN8)
 			{
 				taskBar=FindTaskBarInfoBar(msg->hwnd);
 				if (taskBar && !PointAroundStartButton(taskBar->taskbarId))
@@ -4003,7 +4005,7 @@ if (!g_bTrimHooks)
 				else
 				{
 					bShowCSMenu=(GetSettingBool(L"ShiftRight")==(GetKeyState(VK_SHIFT)<0));
-					bShowWinX=winVer>=WIN_VER_WIN8 && !bShowCSMenu;
+					bShowWinX=winVer>=_WIN32_WINNT_WIN8 && !bShowCSMenu;
 				}
 				bShowWin7=!bShowCSMenu && g_WinStartButton && msg->hwnd!=g_WinStartButton;
 
@@ -4157,7 +4159,7 @@ HBITMAP GetStartScreenIcon( int size )
 	// for sizes<32 use the system background color
 	StartScreenThumbInfo info={{size<64?64:size}};
 	info.size.cy=info.size.cx;
-	if (size>=32 && g_AppManagerThread && GetWinVersion()==WIN_VER_WIN8)
+	if (size>=32 && g_AppManagerThread && GetWinVersion()==_WIN32_WINNT_WIN8)
 	{
 		info.event=CreateEvent(NULL,TRUE,FALSE,NULL);
 		PostThreadMessage(g_AppManagerThread,g_StartMenuMsg,MSG_METROTHUMBNAIL,(LPARAM)&info);
@@ -4209,7 +4211,7 @@ HBITMAP GetStartScreenIcon( int size )
 		}
 		SetDCBrushColor(hDst,color);
 		FillRect(hDst,&rc,(HBRUSH)GetStockObject(DC_BRUSH));
-		HICON hIcon=(HICON)LoadImage(g_Instance,MAKEINTRESOURCE(GetWinVersion()>=WIN_VER_WIN10?IDI_START10:IDI_START),IMAGE_ICON,size,size,LR_DEFAULTCOLOR);
+		HICON hIcon=(HICON)LoadImage(g_Instance,MAKEINTRESOURCE(GetWinVersion()>=_WIN32_WINNT_WIN10?IDI_START10:IDI_START),IMAGE_ICON,size,size,LR_DEFAULTCOLOR);
 		DrawIconEx(hDst,0,0,hIcon,size,size,0,NULL,DI_NORMAL);
 		DestroyIcon(hIcon);
 	}

--- a/Src/StartMenu/StartMenuDLL/TouchHelper.h
+++ b/Src/StartMenu/StartMenuDLL/TouchHelper.h
@@ -1,5 +1,5 @@
 // Classic Shell (c) 2009-2017, Ivo Beltchev
-// Open-Shell (c) 2017-2018, The Open-Shell Team
+// Open-Shell (c) 2017-2024, The Open-Shell Team
 // Confidential information of Ivo Beltchev. Not for disclosure or distribution without prior written consent from the author
 
 #pragma once
@@ -95,29 +95,6 @@ typedef struct tagPOINTER_INFO {
     UINT64          PerformanceCount;
     POINTER_BUTTON_CHANGE_TYPE ButtonChangeType;
 } POINTER_INFO;
-
-typedef enum tagINPUT_MESSAGE_DEVICE_TYPE  {
-     IMDT_UNAVAILABLE = 0x00000000,      // not specified
-     IMDT_KEYBOARD    = 0x00000001,      // from keyboard
-     IMDT_MOUSE       = 0x00000002,      // from mouse
-     IMDT_TOUCH       = 0x00000004,      // from touch
-     IMDT_PEN         = 0x00000008,      // from pen
- } INPUT_MESSAGE_DEVICE_TYPE;
-
-typedef enum tagINPUT_MESSAGE_ORIGIN_ID {
-     IMO_UNAVAILABLE = 0x00000000,  // not specified
-     IMO_HARDWARE    = 0x00000001,  // from a hardware device or injected by a UIAccess app
-     IMO_INJECTED    = 0x00000002,  // injected via SendInput() by a non-UIAccess app
-     IMO_SYSTEM      = 0x00000004,  // injected by the system
-} INPUT_MESSAGE_ORIGIN_ID;
-
-/*
- * Input source structure.
- */
- typedef struct tagINPUT_MESSAGE_SOURCE {
-     INPUT_MESSAGE_DEVICE_TYPE deviceType;
-     INPUT_MESSAGE_ORIGIN_ID   originId;
- } INPUT_MESSAGE_SOURCE;
 
 #endif
 

--- a/Src/StartMenu/StartMenuDLL/stdafx.h
+++ b/Src/StartMenu/StartMenuDLL/stdafx.h
@@ -8,6 +8,8 @@
 #include "targetver.h"
 
 #define STRICT_TYPED_ITEMIDS
+#define VC_EXTRALEAN
+#define NOMINMAX
 // Windows Header Files:
 #include <windows.h>
 #include <commctrl.h>
@@ -16,6 +18,7 @@
 
 #define _ATL_MODULES // compatibility with /permissive-
 #define _ATL_CSTRING_EXPLICIT_CONSTRUCTORS      // some CString constructors will be explicit
+#define _ATL_ALL_WARNINGS
 
 #include <atlbase.h>
 #include <atltypes.h>

--- a/Src/StartMenu/StartMenuDLL/targetver.h
+++ b/Src/StartMenu/StartMenuDLL/targetver.h
@@ -7,18 +7,15 @@
 
 // Modify the following defines if you have to target a platform prior to the ones specified below.
 // Refer to MSDN for the latest info on corresponding values for different platforms.
-#ifndef WINVER                          // Specifies that the minimum required platform is Windows 7.
-#define WINVER 0x0602           // Change this to the appropriate value to target other versions of Windows.
+
+#ifndef _WIN32_WINNT                   // Specifies that the minimum required platform is Windows 7.
+#define _WIN32_WINNT _WIN32_WINNT_WIN7 // Change this to the appropriate value to target other versions of Windows.
 #endif
 
-#ifndef _WIN32_WINNT            // Specifies that the minimum required platform is Windows 7.
-#define _WIN32_WINNT 0x0602     // Change this to the appropriate value to target other versions of Windows.
+#ifndef _WIN32_IE                      // Specifies that the minimum required platform is Internet Explorer 11.0.
+#define _WIN32_IE _WIN32_IE_IE110      // Change this to the appropriate value to target other versions of IE.
 #endif
 
-#ifndef _WIN32_WINDOWS          // Specifies that the minimum required platform is Windows 98.
-#define _WIN32_WINDOWS 0x0410 // Change this to the appropriate value to target Windows Me or later.
-#endif
-
-#ifndef _WIN32_IE                       // Specifies that the minimum required platform is Internet Explorer 7.0.
-#define _WIN32_IE 0x0700        // Change this to the appropriate value to target other versions of IE.
+#ifndef NTDDI_VERSION                  // Specifies that the minimum required platform is NTDDI for Windows 8.
+#define NTDDI_VERSION NTDDI_WIN8       // Change this to the appropriate value to target other versions of NTDDI.
 #endif

--- a/Src/StartMenu/StartMenuHelper/StartMenuHelper.cpp
+++ b/Src/StartMenu/StartMenuHelper/StartMenuHelper.cpp
@@ -332,9 +332,9 @@ STDAPI DllRegisterServer(void)
 	BOOL bWow64=FALSE;
 	// GetVersion lies! it always returns Vista when running inside msiexec. must check version of some system dll
 	WORD winVer=HIWORD(GetVersionEx(GetModuleHandle(L"user32.dll")));
-	if (SUCCEEDED(hr) && winVer>=WIN_VER_WIN8 && IsWow64Process(GetCurrentProcess(),&bWow64) && !bWow64)
+	if (SUCCEEDED(hr) && winVer>=_WIN32_WINNT_WIN8 && IsWow64Process(GetCurrentProcess(),&bWow64) && !bWow64)
 	{
-		AddRegistryKeys(winVer>=WIN_VER_WIN10);
+		AddRegistryKeys(winVer>=_WIN32_WINNT_WIN10);
 		InstallUpgradeTask(true);
 	}
 	
@@ -352,9 +352,9 @@ STDAPI DllUnregisterServer(void)
 #ifdef BUILD_SETUP
 	BOOL bWow64=FALSE;
 	WORD winVer=HIWORD(GetVersionEx(GetModuleHandle(L"user32.dll")));
-	if (winVer>=WIN_VER_WIN8 && IsWow64Process(GetCurrentProcess(),&bWow64) && !bWow64)
+	if (winVer>=_WIN32_WINNT_WIN8 && IsWow64Process(GetCurrentProcess(),&bWow64) && !bWow64)
 	{
-		RemoveRegistryKeys(winVer>=WIN_VER_WIN10);
+		RemoveRegistryKeys(winVer>=_WIN32_WINNT_WIN10);
 		InstallUpgradeTask(false);
 	}
 #endif

--- a/Src/StartMenu/StartMenuHelper/stdafx.h
+++ b/Src/StartMenu/StartMenuHelper/stdafx.h
@@ -14,6 +14,9 @@
 #define _ATL_NO_AUTOMATIC_NAMESPACE
 #define _ATL_MODULES // compatibility with /permissive-
 #define _ATL_CSTRING_EXPLICIT_CONSTRUCTORS	// some CString constructors will be explicit
+#define VC_EXTRALEAN
+#define NOMINMAX
+#define _ATL_ALL_WARNINGS
 
 #include "resource.h"
 #include <atlbase.h>

--- a/Src/StartMenu/StartMenuHelper/targetver.h
+++ b/Src/StartMenu/StartMenuHelper/targetver.h
@@ -7,18 +7,15 @@
 
 // Modify the following defines if you have to target a platform prior to the ones specified below.
 // Refer to MSDN for the latest info on corresponding values for different platforms.
-#ifndef WINVER                          // Specifies that the minimum required platform is Windows 7.
-#define WINVER 0x0602           // Change this to the appropriate value to target other versions of Windows.
+
+#ifndef _WIN32_WINNT                   // Specifies that the minimum required platform is Windows 7.
+#define _WIN32_WINNT _WIN32_WINNT_WIN7 // Change this to the appropriate value to target other versions of Windows.
 #endif
 
-#ifndef _WIN32_WINNT            // Specifies that the minimum required platform is Windows 7.
-#define _WIN32_WINNT 0x0602     // Change this to the appropriate value to target other versions of Windows.
+#ifndef _WIN32_IE                      // Specifies that the minimum required platform is Internet Explorer 11.0.
+#define _WIN32_IE _WIN32_IE_IE110      // Change this to the appropriate value to target other versions of IE.
 #endif
 
-#ifndef _WIN32_WINDOWS          // Specifies that the minimum required platform is Windows 98.
-#define _WIN32_WINDOWS 0x0410 // Change this to the appropriate value to target Windows Me or later.
-#endif
-
-#ifndef _WIN32_IE                       // Specifies that the minimum required platform is Internet Explorer 7.0.
-#define _WIN32_IE 0x0700        // Change this to the appropriate value to target other versions of IE.
+#ifndef NTDDI_VERSION                  // Specifies that the minimum required platform is NTDDI for Windows 8.
+#define NTDDI_VERSION NTDDI_WIN8       // Change this to the appropriate value to target other versions of NTDDI.
 #endif

--- a/Src/StartMenu/stdafx.h
+++ b/Src/StartMenu/stdafx.h
@@ -8,6 +8,10 @@
 #include "targetver.h"
 
 #define STRICT_TYPED_ITEMIDS
+#define WIN32_LEAN_AND_MEAN
+#define VC_EXTRALEAN
+#define NOMINMAX
+#define _ATL_ALL_WARNINGS
 // Windows Header Files:
 #include <windows.h>
 #include <commctrl.h>

--- a/Src/StartMenu/targetver.h
+++ b/Src/StartMenu/targetver.h
@@ -7,18 +7,15 @@
 
 // Modify the following defines if you have to target a platform prior to the ones specified below.
 // Refer to MSDN for the latest info on corresponding values for different platforms.
-#ifndef WINVER                          // Specifies that the minimum required platform is Windows 7.
-#define WINVER 0x0602           // Change this to the appropriate value to target other versions of Windows.
+
+#ifndef _WIN32_WINNT                   // Specifies that the minimum required platform is Windows 7.
+#define _WIN32_WINNT _WIN32_WINNT_WIN7 // Change this to the appropriate value to target other versions of Windows.
 #endif
 
-#ifndef _WIN32_WINNT            // Specifies that the minimum required platform is Windows 7.
-#define _WIN32_WINNT 0x0602     // Change this to the appropriate value to target other versions of Windows.
+#ifndef _WIN32_IE                      // Specifies that the minimum required platform is Internet Explorer 11.0.
+#define _WIN32_IE _WIN32_IE_IE110      // Change this to the appropriate value to target other versions of IE.
 #endif
 
-#ifndef _WIN32_WINDOWS          // Specifies that the minimum required platform is Windows 98.
-#define _WIN32_WINDOWS 0x0410 // Change this to the appropriate value to target Windows Me or later.
-#endif
-
-#ifndef _WIN32_IE                       // Specifies that the minimum required platform is Internet Explorer 7.0.
-#define _WIN32_IE 0x0700        // Change this to the appropriate value to target other versions of IE.
+#ifndef NTDDI_VERSION                  // Specifies that the minimum required platform is NTDDI for Windows 8.
+#define NTDDI_VERSION NTDDI_WIN8       // Change this to the appropriate value to target other versions of NTDDI.
 #endif

--- a/Src/Update/DesktopToasts/DesktopNotificationManagerCompat.h
+++ b/Src/Update/DesktopToasts/DesktopNotificationManagerCompat.h
@@ -1,7 +1,7 @@
 // ******************************************************************
 // Copyright (c) Microsoft. All rights reserved.
 // This code is licensed under the MIT License (MIT).
-// THE CODE IS PROVIDED ìAS ISî, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// THE CODE IS PROVIDED ‚ÄúAS IS‚Äù, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
 // INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
 // IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -13,6 +13,9 @@
 #pragma once
 #include <string>
 #include <memory>
+#define WIN32_LEAN_AND_MEAN
+#define VC_EXTRALEAN
+#define NOMINMAX
 #include <Windows.h>
 #include <windows.ui.notifications.h>
 #include <wrl.h>

--- a/Src/Update/DesktopToasts/dllmain.cpp
+++ b/Src/Update/DesktopToasts/dllmain.cpp
@@ -1,5 +1,7 @@
 // dllmain.cpp : Defines the entry point for the DLL application.
 #define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers
+#define VC_EXTRALEAN
+#define NOMINMAX
 #include <windows.h>
 #include <NotificationActivationCallback.h>
 #include <windows.ui.notifications.h>

--- a/Src/Update/Update.cpp
+++ b/Src/Update/Update.cpp
@@ -1,9 +1,12 @@
 // Classic Shell (c) 2009-2017, Ivo Beltchev
-// Open-Shell (c) 2017-2018, The Open-Shell Team
+// Open-Shell (c) 2017-2024, The Open-Shell Team
 // Confidential information of Ivo Beltchev. Not for disclosure or distribution without prior written consent from the author
 
 #define STRICT_TYPED_ITEMIDS
 #define _ATL_CSTRING_EXPLICIT_CONSTRUCTORS	// some CString constructors will be explicit
+#define _ATL_ALL_WARNINGS
+#define VC_EXTRALEAN
+#define NOMINMAX
 #include <windows.h>
 #include <atlbase.h>
 #include <atlwin.h>


### PR DESCRIPTION
Probably fixed #2055 and may'be other Windows 7 related issues.

_WIN32_WINNT is set for Windows 7.
NTDDI_VERSION is set for Windows 8.
_WIN32_IE is set for IE11.
_WIN32_WINDOWS define is removed because it's usefulness.

#define _ATL_ALL_WARNINGS
#define VC_EXTRALEAN
#define NOMINMAX
#define WIN32_LEAN_AND_MEAN (if it's possible)

Fix copy-pasted code from SDK and disable code for Windows Vista in the compile time because we don't support Vista.