### PR TITLE
Fix search auto-selecting wrong item before programs finish loading

### DIFF
--- a/Src/StartMenu/StartMenuDLL/MenuContainer.cpp
+++ b/Src/StartMenu/StartMenuDLL/MenuContainer.cpp
@@ -6366,7 +6366,10 @@ LRESULT CMenuContainer::OnRefresh( UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL
 					}
 				}
 				else if (m_Items[m_OriginalCount].id==MENU_SEARCH_CATEGORY)
-					hotItem=m_OriginalCount+1;
+				{
+					if (!bSearching || !s_SearchResults.programs.empty())
+						hotItem=m_OriginalCount+1;
+				}
 			}
 			else
 				hotItem=-1;


### PR DESCRIPTION
## Summary

- Fix search auto-selecting Settings/Control Panel items before Programs load
- When search is still collecting programs, skip auto-selection until programs are ready
- 3-line change in `OnRefresh()`, no behavior change once search completes

## Related Issues

Related to #456 — typing program name fast sometimes launches wrong program
Related to #1982 — search results reorder while user tries to select (mouse interaction, different code path)
Related to #4 — search results shift mid-click (same as #1982)

## Problem

When typing fast in the search box (e.g. `sc`), the UI refreshes with partial results. Programs take ~220ms to collect from Start Menu folders. During that window, if only Settings/Control Panel results are available, `OnRefresh()` blindly auto-selects the first result, which is a Settings item. If the user hits Enter before programs finish loading, the wrong item launches.

The root cause is an early `RefreshSearch()` call in `SearchThread()` that fires before program collection begins (when `m_ProgramItemsOld` is not empty). This pushes stale/filtered results to the UI, and `OnRefresh()` auto-selects `m_OriginalCount+1` without checking whether programs have loaded.

## Fix

In `MenuContainer.cpp` `OnRefresh()`, defer auto-selection when search is still in progress and no programs have been found yet. The cursor stays unset until the next refresh after programs load, which then selects correctly.

## Evidence

**Before (wrong auto-select on Settings):**

https://github.com/user-attachments/assets/9cd307cd-d354-4dbb-b41e-f1fcc3ba277b

**After (waits for Programs before selecting):**

https://github.com/user-attachments/assets/b22a8450-8084-4ce0-8e99-fe5ce3d42791

## Test plan

- Type `sc` rapidly in search box, verify Programs category selected first
- Type queries that match only Settings (no program matches), verify Settings selected after search completes
- Press Enter before results load, verify no premature execution
- Normal typing speed, verify no visible delay in selection

> 🤖 Generated with [Claude Code](https://claude.ai/code)